### PR TITLE
fix(balances): error when requesting a balances of a specific address when private key is undefined

### DIFF
--- a/tasks/balances.ts
+++ b/tasks/balances.ts
@@ -123,7 +123,7 @@ const main = async (args: any, hre: HardhatRuntimeEnvironment) => {
 
   if (args.address) {
     address = args.address;
-  } else if (process.env.PRIVATE_KEY) {
+  } else if (pk) {
     address = new ethers.Wallet(pk).address;
     btc_address = bitcoinAddress(pk);
   } else {
@@ -141,8 +141,7 @@ const main = async (args: any, hre: HardhatRuntimeEnvironment) => {
   const filteredBalances = balances.filter((balance) => balance != null);
   spinner.stop();
   console.log(`
-EVM: ${address}
-BTC: ${bitcoinAddress(pk)}
+EVM: ${address} ${btc_address ? `\nBitcoin: ${btc_address}` : ""}
 `);
   console.table(filteredBalances);
 };


### PR DESCRIPTION
Fixes an error when you tried querying a balance of an address and you didn't have a private key defined:

```
npx hardhat balances --address 0xa168cCF5dBDA0f32819f5F2822eF4437d8a962Ba
An unexpected error occurred:

TypeError [ERR_INVALID_ARG_TYPE]: The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received undefined
    at new NodeError (node:internal/errors:399:5)
    at Function.from (node:buffer:335:9)
    at bitcoinAddress (/Users/fadeev/github.com/zeta-chain/toolkit/lib/bitcoinAddress.ts:9:44)
    at SimpleTaskDefinition.main [as action] (/Users/fadeev/github.com/zeta-chain/toolkit/tasks/balances.ts:145:22)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Environment._runTaskDefinition (/Users/fadeev/github.com/zeta-chain/toolkit/node_modules/hardhat/src/internal/core/runtime-environment.ts:333:14)
    at async Environment.run (/Users/fadeev/github.com/zeta-chain/toolkit/node_modules/hardhat/src/internal/core/runtime-environment.ts:166:14)
    at async main (/Users/fadeev/github.com/zeta-chain/toolkit/node_modules/hardhat/src/internal/cli/cli.ts:280:7) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```