### PR TITLE
feat: Hardhat task to fetch CCM and zEVM fees

### DIFF
--- a/helpers/fees.ts
+++ b/helpers/fees.ts
@@ -1,0 +1,87 @@
+import { getEndpoints } from "@zetachain/networks";
+import { getAddress } from "@zetachain/protocol-contracts";
+import ZRC20 from "@zetachain/protocol-contracts/abi/zevm/ZRC20.sol/ZRC20.json";
+import axios from "axios";
+import { formatEther, parseEther } from "ethers/lib/utils";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+
+export type FeeDetails = {
+  gasFee: string;
+  protocolFee: string;
+  totalFee: string;
+};
+
+const GAS_LIMIT = 350000;
+
+export const getFee = async (
+  type: "ccm" | "zevm",
+  network: string,
+  hre: HardhatRuntimeEnvironment
+) => {
+  const { ethers } = hre as any;
+  const { url } = hre.config.networks["zeta_testnet"] as any;
+  const provider = new ethers.providers.JsonRpcProvider(url);
+
+  const API = getEndpoints("cosmos-http", "zeta_testnet")[0]?.url;
+  if (!API) {
+    throw new Error("getEndpoints: API endpoint not found");
+  }
+
+  if (type === "zevm") {
+    return fetchZEVMFees(network, provider, hre);
+  } else if (type === "ccm") {
+    return fetchCCMFees(network, hre);
+  }
+};
+
+const formatTo18Decimals = (n: any) => parseFloat(formatEther(n)).toFixed(18);
+
+export const fetchZEVMFees = async (
+  network: string,
+  provider: any,
+  hre: HardhatRuntimeEnvironment
+) => {
+  const zrc20Address = getAddress("zrc20", network);
+  if (!zrc20Address) return;
+
+  const contract = new hre.ethers.Contract(zrc20Address, ZRC20.abi, provider);
+
+  const gasFee = hre.ethers.BigNumber.from(
+    (await contract.withdrawGasFee())[1]
+  );
+  const protocolFee = hre.ethers.BigNumber.from(
+    await contract.PROTOCOL_FLAT_FEE()
+  );
+
+  return {
+    /* eslint-disable */
+    totalFee: formatTo18Decimals(gasFee.add(protocolFee)),
+    gasFee: formatTo18Decimals(gasFee),
+    protocolFee: formatTo18Decimals(protocolFee),
+    /* eslint-enable */
+  } as FeeDetails;
+};
+
+export const fetchCCMFees = async (
+  network: string,
+  hre: HardhatRuntimeEnvironment
+) => {
+  const API = getEndpoints("cosmos-http", "zeta_testnet")[0]?.url;
+  if (!API) {
+    throw new Error("getEndpoints: API endpoint not found");
+  }
+
+  const url = `${API}/zeta-chain/crosschain/convertGasToZeta?chain=${network}&gasLimit=${GAS_LIMIT}`;
+  const { data } = await axios.get(url);
+
+  const gasFee = hre.ethers.BigNumber.from(data.outboundGasInZeta);
+  const protocolFee = hre.ethers.BigNumber.from(data.protocolFeeInZeta);
+
+  return {
+    /* eslint-disable */
+    totalFee: formatTo18Decimals(gasFee.add(protocolFee)),
+    gasFee: formatTo18Decimals(gasFee),
+    protocolFee: formatTo18Decimals(protocolFee),
+    /* eslint-enable */
+  } as FeeDetails;
+};

--- a/helpers/fees.ts
+++ b/helpers/fees.ts
@@ -41,7 +41,9 @@ export const fetchZEVMFees = async (
   provider: any,
   hre: HardhatRuntimeEnvironment
 ) => {
-  const zrc20Address = getAddress("zrc20", network);
+  const btcZRC20 = "0x65a45c57636f9BcCeD4fe193A602008578BcA90b"; // TODO: use getAddress("zrc20", "btc_testnet") when available
+  const zrc20Address =
+    network === "btc_testnet" ? btcZRC20 : getAddress("zrc20", network);
   if (!zrc20Address) return;
 
   const contract = new hre.ethers.Contract(zrc20Address, ZRC20.abi, provider);

--- a/tasks/fees.ts
+++ b/tasks/fees.ts
@@ -1,0 +1,41 @@
+import { getEndpoints } from "@zetachain/networks";
+import { task } from "hardhat/config";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+
+import type { FeeDetails } from "../helpers/fees";
+import { fetchCCMFees, fetchZEVMFees } from "../helpers/fees";
+
+const main = async (args: any, hre: HardhatRuntimeEnvironment) => {
+  const { ethers } = hre as any;
+  const { url } = hre.config.networks["zeta_testnet"] as any;
+  const provider = new ethers.providers.JsonRpcProvider(url);
+  const feesZEVM: Record<string, FeeDetails> = {};
+  const feesCCM: Record<string, FeeDetails> = {};
+
+  const networks = Object.keys(hre.config.networks);
+
+  await Promise.all(
+    networks.map(async (network) => {
+      return Promise.all([
+        fetchZEVMFees(network, provider, hre),
+        fetchCCMFees(network, hre),
+      ])
+        .then(([zevmFees, ccmFees]) => {
+          if (zevmFees) feesZEVM[network] = zevmFees;
+          if (ccmFees) feesCCM[network] = ccmFees;
+        })
+        .catch(() => {});
+    })
+  );
+
+  console.log("\nOmnichain fees (in native gas tokens of destination chain):");
+  console.table(feesZEVM);
+  console.log("\nCross-chain messaging fees (in ZETA):");
+  console.table(feesCCM);
+};
+
+export const feesTask = task(
+  "fees",
+  "Show omnichain and cross-chain messaging fees",
+  main
+);

--- a/tasks/fees.ts
+++ b/tasks/fees.ts
@@ -1,10 +1,8 @@
-import { getEndpoints } from "@zetachain/networks";
 import { task } from "hardhat/config";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
 import type { FeeDetails } from "../helpers/fees";
 import { fetchCCMFees, fetchZEVMFees } from "../helpers/fees";
-import { getAddress } from "@zetachain/protocol-contracts";
 
 const main = async (args: any, hre: HardhatRuntimeEnvironment) => {
   const { ethers } = hre as any;

--- a/tasks/fees.ts
+++ b/tasks/fees.ts
@@ -4,6 +4,7 @@ import { HardhatRuntimeEnvironment } from "hardhat/types";
 
 import type { FeeDetails } from "../helpers/fees";
 import { fetchCCMFees, fetchZEVMFees } from "../helpers/fees";
+import { getAddress } from "@zetachain/protocol-contracts";
 
 const main = async (args: any, hre: HardhatRuntimeEnvironment) => {
   const { ethers } = hre as any;
@@ -12,19 +13,19 @@ const main = async (args: any, hre: HardhatRuntimeEnvironment) => {
   const feesZEVM: Record<string, FeeDetails> = {};
   const feesCCM: Record<string, FeeDetails> = {};
 
-  const networks = Object.keys(hre.config.networks);
+  const networks = [...Object.keys(hre.config.networks), "btc_testnet"];
 
   await Promise.all(
-    networks.map(async (network) => {
-      return Promise.all([
-        fetchZEVMFees(network, provider, hre),
-        fetchCCMFees(network, hre),
-      ])
-        .then(([zevmFees, ccmFees]) => {
-          if (zevmFees) feesZEVM[network] = zevmFees;
-          if (ccmFees) feesCCM[network] = ccmFees;
-        })
-        .catch(() => {});
+    networks.map(async (n) => {
+      try {
+        const zevmFees = await fetchZEVMFees(n, provider, hre);
+        if (zevmFees) feesZEVM[n] = zevmFees;
+      } catch (err) {}
+
+      try {
+        const ccmFees = await fetchCCMFees(n, hre);
+        if (ccmFees) feesCCM[n] = ccmFees;
+      } catch (err) {}
     })
   );
 

--- a/tasks/index.ts
+++ b/tasks/index.ts
@@ -2,6 +2,7 @@ export { accountTask } from "./account";
 export { balancesTask } from "./balances";
 export { cctxTask } from "./cctx";
 export { faucetTask } from "./faucet";
+export { feesTask } from "./fees";
 export { messagingTask } from "./messaging";
 export { omnichainTask } from "./omnichain";
 export { sendBTCTask } from "./sendBTC";


### PR DESCRIPTION
```
npx hardhat fees

Omnichain fees (in native gas tokens of destination chain):
┌────────────────┬────────────────────────┬────────────────────────┬────────────────────────┐
│    (index)     │        totalFee        │         gasFee         │      protocolFee       │
├────────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│  btc_testnet   │ '0.000000000000100000' │ '0.000000000000100000' │ '0.000000000000000000' │
│  bsc_testnet   │ '0.000105000000000000' │ '0.000105000000000000' │ '0.000000000000000000' │
│ mumbai_testnet │ '0.000030973009137000' │ '0.000030973009137000' │ '0.000000000000000000' │
│ goerli_testnet │ '0.000000000022680000' │ '0.000000000022680000' │ '0.000000000000000000' │
└────────────────┴────────────────────────┴────────────────────────┴────────────────────────┘

Cross-chain messaging fees (in ZETA):
┌────────────────┬────────────────────────┬────────────────────────┬────────────────────────┐
│    (index)     │        totalFee        │         gasFee         │      protocolFee       │
├────────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│  bsc_testnet   │ '2.013270816836449040' │ '0.013270816836449203' │ '2.000000000000000000' │
│ mumbai_testnet │ '2.000570110936660928' │ '0.000570110936660734' │ '2.000000000000000000' │
│ goerli_testnet │ '2.000000002721283199' │ '0.000000002721283054' │ '2.000000000000000000' │
└────────────────┴────────────────────────┴────────────────────────┴────────────────────────┘
```

`getFee` can be used in the templates to check if a user has submitted enough tokens as fees.