### PR TITLE
feat: update onCrossChainCall with zContext

### DIFF
--- a/templates/omnichain/contracts/{{contractName}}.sol.hbs
+++ b/templates/omnichain/contracts/{{contractName}}.sol.hbs
@@ -12,6 +12,7 @@ contract {{contractName}} is zContract {
     }
 
     function onCrossChainCall(
+        zContext calldata context,
         address zrc20,
         uint256 amount,
         bytes calldata message


### PR DESCRIPTION
Added `zContext calldata context` to the template.

Context: https://github.com/zeta-chain/node/pull/912