### PR TITLE
feat: added `SenderNotSystemContract` check to the omnichain template

### DIFF
--- a/templates/omnichain/contracts/{{contractName}}.sol.hbs
+++ b/templates/omnichain/contracts/{{contractName}}.sol.hbs
@@ -5,6 +5,7 @@ import "@zetachain/protocol-contracts/contracts/zevm/SystemContract.sol";
 import "@zetachain/protocol-contracts/contracts/zevm/interfaces/zContract.sol";
 
 contract {{contractName}} is zContract {
+    error SenderNotSystemContract();
     SystemContract public immutable systemContract;
 
     constructor(address systemContractAddress) {
@@ -17,6 +18,9 @@ contract {{contractName}} is zContract {
         uint256 amount,
         bytes calldata message
     ) external virtual override {
+        if (msg.sender != address(systemContract)) {
+            revert SenderNotSystemContract();
+        }
         {{#if arguments.pairs}}
         ({{#each arguments.pairs}}{{#if @index}}, {{/if}}{{this.[1]}} {{this.[0]}}{{/each}}) = abi.decode(
             message,


### PR DESCRIPTION
Added the following check to the omnichain contract template `onCrossChainCall`:

```solidity
error SenderNotSystemContract();
```

```solidity
if (msg.sender != address(systemContract)) {
    revert SenderNotSystemContract();
}
```