### PR TITLE
refactor(deploy): handle an error when a private key is not found

### DIFF
--- a/templates/omnichain/tasks/deploy.ts.hbs
+++ b/templates/omnichain/tasks/deploy.ts.hbs
@@ -10,6 +10,11 @@ const main = async (args: any, hre: HardhatRuntimeEnvironment) => {
   }
 
   const [signer] = await hre.ethers.getSigners();
+  if (signer === undefined) {
+    throw new Error(
+      `Wallet not found. Please, run "npx hardhat account --save" or set PRIVATE_KEY env variable (for example, in a .env file)`
+    );
+  }
   console.log(`🔑 Using account: ${signer.address}\n`);
 
   const systemContract = getAddress("systemContract", "zeta_testnet");


### PR DESCRIPTION
Without error handling it could be confusing, because Hardhat is throwing `TypeError: Cannot read properties of undefined (reading 'address')`, which is unclear.