### PR TITLE
fix(fees): query gas fees by chain ID

### DIFF
--- a/helpers/fees.ts
+++ b/helpers/fees.ts
@@ -39,7 +39,9 @@ export const fetchCCMFees = async (network: string) => {
     throw new Error("getEndpoints: API endpoint not found");
   }
 
-  const url = `${API}/zeta-chain/crosschain/convertGasToZeta?chain=${network}&gasLimit=${GAS_LIMIT}`;
+  const chainID = getHardhatConfigNetworks()[network].chainId;
+
+  const url = `${API}/zeta-chain/crosschain/convertGasToZeta?chainId=${chainID}&gasLimit=${GAS_LIMIT}`;
   const { data } = await axios.get(url);
 
   const gasFee = ethers.BigNumber.from(data.outboundGasInZeta);


### PR DESCRIPTION
The HTTP has changed: https://github.com/zeta-chain/node/pull/846

Before:

```
npx hardhat fees

Omnichain fees (in native gas tokens of destination chain):
┌────────────────┬────────────────────────┬────────────────────────┬────────────────────────┐
│    (index)     │        totalFee        │         gasFee         │      protocolFee       │
├────────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│ mumbai_testnet │ '0.010031500000378000' │ '0.000031500000378000' │ '0.010000000000000000' │
│ goerli_testnet │ '0.000000009798159000' │ '0.000000009798159000' │ '0.000000000000000000' │
│  bsc_testnet   │ '0.250105000000000022' │ '0.000105000000000000' │ '0.250000000000000000' │
│  btc_testnet   │ '0.000000000000100000' │ '0.000000000000100000' │ '0.000000000000000000' │
└────────────────┴────────────────────────┴────────────────────────┴────────────────────────┘

Cross-chain messaging fees (in ZETA):
┌─────────┐
│ (index) │
├─────────┤
└─────────┘
```

After:

```
Omnichain fees (in native gas tokens of destination chain):
┌────────────────┬────────────────────────┬────────────────────────┬────────────────────────┐
│    (index)     │        totalFee        │         gasFee         │      protocolFee       │
├────────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│  btc_testnet   │ '0.000000000000100000' │ '0.000000000000100000' │ '0.000000000000000000' │
│ goerli_testnet │ '0.000000009798180000' │ '0.000000009798180000' │ '0.000000000000000000' │
│  bsc_testnet   │ '0.250105000000000022' │ '0.000105000000000000' │ '0.250000000000000000' │
│ mumbai_testnet │ '0.010031500000357000' │ '0.000031500000357000' │ '0.010000000000000000' │
└────────────────┴────────────────────────┴────────────────────────┴────────────────────────┘

Cross-chain messaging fees (in ZETA):
┌────────────────┬────────────────────────┬────────────────────────┬────────────────────────┐
│    (index)     │        totalFee        │         gasFee         │      protocolFee       │
├────────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│ goerli_testnet │ '2.000003846070423030' │ '0.000003846070423151' │ '2.000000000000000000' │
│  bsc_testnet   │ '2.001596709013458320' │ '0.001596709013458155' │ '2.000000000000000000' │
│ mumbai_testnet │ '2.000192399982356761' │ '0.000192399982356547' │ '2.000000000000000000' │
└────────────────┴────────────────────────┴────────────────────────┴────────────────────────┘
```