### PR TITLE
 feat(cctx): accept both inbound and cctx hash

### DIFF
--- a/helpers/tx.ts
+++ b/helpers/tx.ts
@@ -1,9 +1,9 @@
 import { getEndpoints } from "@zetachain/networks";
 import axios from "axios";
 import clc from "cli-color";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
 import Spinnies from "spinnies";
 import WebSocket from "ws";
-import { HardhatRuntimeEnvironment } from "hardhat/types";
 
 const getEndpoint = (key: any): string => {
   const endpoint = getEndpoints(key, "zeta_testnet")[0]?.url;
@@ -80,10 +80,10 @@ const fetchCCTXData = async (
     confirmed_on_destination = confirmed !== null;
   }
   const tx = {
-    receiver_chainId,
     confirmed_on_destination,
-    outbound_tx_tss_nonce: cctx.outbound_tx_params[0].outbound_tx_tss_nonce,
     outbound_tx_hash,
+    outbound_tx_tss_nonce: cctx.outbound_tx_params[0].outbound_tx_tss_nonce,
+    receiver_chainId,
     sender_chain_id: cctx.inbound_tx_params.sender_chain_id,
     status: cctx.cctx_status.status,
     status_message: cctx.cctx_status.status_message,

--- a/helpers/tx.ts
+++ b/helpers/tx.ts
@@ -124,7 +124,9 @@ export const trackCCTX = async (inboundTxHash: string): Promise<void> => {
           });
         }
       }
-      await fetchCCTXByInbound(inboundTxHash, spinnies, API, cctxList);
+      if (Object.keys(cctxList).length === 0) {
+        await fetchCCTXByInbound(inboundTxHash, spinnies, API, cctxList);
+      }
       for (const txHash in cctxList) {
         await fetchCCTXByInbound(txHash, spinnies, API, cctxList);
       }

--- a/helpers/tx.ts
+++ b/helpers/tx.ts
@@ -90,6 +90,14 @@ const fetchCCTXData = async (
   }
 };
 
+const isCCTX = async (hash: string, API: string) => {
+  try {
+    const url = `${API}/zeta-chain/crosschain/cctx/${hash}`;
+    const apiResponse = await axios.get(url);
+    return apiResponse?.data?.CrossChainTx ? true : false;
+  } catch (e) {}
+};
+
 export const trackCCTX = async (inboundTxHash: string): Promise<void> => {
   const spinnies = new Spinnies();
 
@@ -107,6 +115,15 @@ export const trackCCTX = async (inboundTxHash: string): Promise<void> => {
         });
         await fetchCCTX(inboundTxHash, spinnies, API, cctxList);
       }
+      if ((await isCCTX(inboundTxHash, API)) && !cctxList[inboundTxHash]) {
+        cctxList[inboundTxHash] = [];
+        if (!spinnies.spinners[`spinner-${inboundTxHash}`]) {
+          spinnies.add(`spinner-${inboundTxHash}`, {
+            text: `${inboundTxHash}`,
+          });
+        }
+      }
+      await fetchCCTX(inboundTxHash, spinnies, API, cctxList);
       for (const txHash in cctxList) {
         await fetchCCTX(txHash, spinnies, API, cctxList);
       }

--- a/helpers/tx.ts
+++ b/helpers/tx.ts
@@ -97,10 +97,10 @@ const fetchCCTXData = async (
     const receiver = cctxList[cctxHash]?.[0].receiver_chainId;
     const pendingNonce = pendingNonces.find(
       (n: any) => n.chain_id === tx.receiver_chainId
-    )?.nonce_high;
+    )?.nonce_low;
     const txNonce = tx.outbound_tx_tss_nonce;
     const queue =
-      txNonce > pendingNonce ? ` ${txNonce - pendingNonce} remaining` : "";
+      txNonce > pendingNonce ? ` (${txNonce - pendingNonce} in queue)` : "";
     const path = cctxList[cctxHash]
       .map(
         (x: any) =>

--- a/helpers/tx.ts
+++ b/helpers/tx.ts
@@ -124,9 +124,6 @@ export const trackCCTX = async (inboundTxHash: string): Promise<void> => {
           });
         }
       }
-      if (Object.keys(cctxList).length === 0) {
-        await fetchCCTXByInbound(inboundTxHash, spinnies, API, cctxList);
-      }
       for (const txHash in cctxList) {
         await fetchCCTXByInbound(txHash, spinnies, API, cctxList);
       }

--- a/helpers/tx.ts
+++ b/helpers/tx.ts
@@ -110,10 +110,11 @@ export const trackCCTX = async (inboundTxHash: string): Promise<void> => {
     const socket = new WebSocket(WSS);
     socket.on("open", () => socket.send(JSON.stringify(SUBSCRIBE_MESSAGE)));
     socket.on("message", async () => {
+      console.log(cctxList);
       if (Object.keys(cctxList).length === 0) {
-        spinnies.add(`search`, {
-          text: `Looking for cross-chain transactions (CCTXs) on ZetaChain...\n`,
-        });
+        // spinnies.add(`search`, {
+        //   text: `Looking for cross-chain transactions (CCTXs) on ZetaChain...\n`,
+        // });
         await fetchCCTXByInbound(inboundTxHash, spinnies, API, cctxList);
       }
       if ((await getCCTX(inboundTxHash, API)) && !cctxList[inboundTxHash]) {

--- a/helpers/tx.ts
+++ b/helpers/tx.ts
@@ -88,7 +88,6 @@ const fetchCCTXData = async (
     status: cctx.cctx_status.status,
     status_message: cctx.cctx_status.status_message,
   };
-  // tx.provider = hre.config.networks;
   const lastCCTX = cctxList[cctxHash][cctxList[cctxHash].length - 1];
   const isEmpty = cctxList[cctxHash].length === 0;
   if (isEmpty || lastCCTX?.status !== tx.status) {

--- a/helpers/tx.ts
+++ b/helpers/tx.ts
@@ -73,17 +73,19 @@ const fetchCCTXData = async (
       text: `${cctxHash}: ${sender} → ${receiver}: ${path}`,
     };
     const id = `spinner-${cctxHash}`;
-    switch (tx.status) {
-      case "OutboundMined":
-      case "Reverted":
-        spinnies.succeed(id, text);
-        break;
-      case "Aborted":
-        spinnies.fail(id, text);
-        break;
-      default:
-        spinnies.update(id, text);
-        break;
+    if (spinnies.spinners[id]) {
+      switch (tx.status) {
+        case "OutboundMined":
+        case "Reverted":
+          spinnies.succeed(id, text);
+          break;
+        case "Aborted":
+          spinnies.fail(id, text);
+          break;
+        default:
+          spinnies.update(id, text);
+          break;
+      }
     }
   }
 };
@@ -100,7 +102,8 @@ export const trackCCTX = async (inboundTxHash: string): Promise<void> => {
   const spinnies = new Spinnies();
 
   const API = getEndpoint("cosmos-http");
-  const WSS = getEndpoint("tendermint-ws");
+  // const WSS = getEndpoint("tendermint-ws");
+  const WSS = "wss://rpc-archive.athens.zetachain.com:26657/websocket";
 
   return new Promise((resolve, reject) => {
     let cctxList: any = {};
@@ -147,7 +150,7 @@ export const trackCCTX = async (inboundTxHash: string): Promise<void> => {
           .filter((s) => !["OutboundMined", "Aborted", "Reverted"].includes(s))
           .length === 0
       ) {
-        socket.close();
+        // socket.close();
       }
     });
     socket.on("error", (error: any) => {

--- a/helpers/tx.ts
+++ b/helpers/tx.ts
@@ -110,11 +110,10 @@ export const trackCCTX = async (inboundTxHash: string): Promise<void> => {
     const socket = new WebSocket(WSS);
     socket.on("open", () => socket.send(JSON.stringify(SUBSCRIBE_MESSAGE)));
     socket.on("message", async () => {
-      console.log(cctxList);
       if (Object.keys(cctxList).length === 0) {
-        // spinnies.add(`search`, {
-        //   text: `Looking for cross-chain transactions (CCTXs) on ZetaChain...\n`,
-        // });
+        spinnies.add(`search`, {
+          text: `Looking for cross-chain transactions (CCTXs) on ZetaChain...\n`,
+        });
         await fetchCCTXByInbound(inboundTxHash, spinnies, API, cctxList);
       }
       if ((await getCCTX(inboundTxHash, API)) && !cctxList[inboundTxHash]) {

--- a/tasks/cctx.ts
+++ b/tasks/cctx.ts
@@ -13,4 +13,4 @@ export const cctxTask = task(
   "cctx",
   "Track cross-chain transaction status",
   main
-).addParam("tx", "Inbound transaction hash");
+).addPositionalParam("tx", "TX hash of an inbound transaction or a CCTX");

--- a/tasks/cctx.ts
+++ b/tasks/cctx.ts
@@ -6,11 +6,13 @@ import { trackCCTX } from "../helpers";
 declare const hre: any;
 
 const main = async (args: any, hre: HardhatRuntimeEnvironment) => {
-  await trackCCTX(args.tx);
+  await trackCCTX(args.tx, args.json);
 };
 
 export const cctxTask = task(
   "cctx",
   "Track cross-chain transaction status",
   main
-).addPositionalParam("tx", "TX hash of an inbound transaction or a CCTX");
+)
+  .addPositionalParam("tx", "TX hash of an inbound transaction or a CCTX")
+  .addFlag("json", "Output as JSON");

--- a/tasks/cctx.ts
+++ b/tasks/cctx.ts
@@ -6,7 +6,7 @@ import { trackCCTX } from "../helpers";
 declare const hre: any;
 
 const main = async (args: any, hre: HardhatRuntimeEnvironment) => {
-  await trackCCTX(args.tx, args.json);
+  await trackCCTX(args.tx, hre, args.json);
 };
 
 export const cctxTask = task(


### PR DESCRIPTION
* Shows how many CCTXs are pending in front of the one you're tracking
* Replaced BlockPI with ZetaChain's own WSS, because the former one was closing connection after 1 block (decided not to make a reconnecting socket for now)
* Added `--json` for non-interactive use
* Checks a tx on the destination chain. Currently not used in the UI, but this is good to have for integration testing: broadcast a tx, then run `npx hardhat cctx --json` and read the output to check that the CCTX has been successfully processed on the destination chain.

```
npx hardhat cctx 0xe6cac4dc7b978806bdd37262f3253289fb8a160a855275faf28a5196aa5ba4a9

✓ CCTXs on ZetaChain found.

✓ 0x0967302e138ad26abf9a4f40c2bd6c234324f650db2b4b50f39332d230c64fb4: 80001 → 7001: OutboundMined (Remote omnichain contract call completed)
✓ 0x0b9f9e90dc6eaddc4129a35efa9a34bdc08b3dfd4e778a8385aa9b33d44a74e6: 7001 → 5: OutboundMined 
✓ 0x63d075e03928ff060a2fe9eae3efada4a8c3c4321f64e079de28fabb98d74c03: 7001 → 97: OutboundMined 
```

```
npx hardhat cctx 0x0967302e138ad26abf9a4f40c2bd6c234324f650db2b4b50f39332d230c64fb4

✓ CCTXs on ZetaChain found.

✓ 0x0967302e138ad26abf9a4f40c2bd6c234324f650db2b4b50f39332d230c64fb4: 80001 → 7001: OutboundMined (Remote omnichain contract call completed)
✓ 0x0b9f9e90dc6eaddc4129a35efa9a34bdc08b3dfd4e778a8385aa9b33d44a74e6: 7001 → 5: OutboundMined 
✓ 0x63d075e03928ff060a2fe9eae3efada4a8c3c4321f64e079de28fabb98d74c03: 7001 → 97: OutboundMined 
```

```
npx hardhat cctx 0x15ffebf79fa050c2bc1a1eb5abaaf88c9332f327c5b3e0c564fe0c90eba74cf3

✓ CCTXs on ZetaChain found.

✓ 0xb3c209fbe8eb556914bd2151d0a3c4b10325c36389dc4ee57d10153e6f50cc2b: 7001 → 5: OutboundMined 
✓ 0x15ffebf79fa050c2bc1a1eb5abaaf88c9332f327c5b3e0c564fe0c90eba74cf3: 80001 → 7001: OutboundMined (Remote omnichain contract call completed)
```