### PR TITLE
feat: added `bytesToBech32Bytes` helper function

### DIFF
--- a/contracts/BytesHelperLib.sol
+++ b/contracts/BytesHelperLib.sol
@@ -27,4 +27,16 @@ library BytesHelperLib {
     ) internal pure returns (bytes32) {
         return bytes32(uint256(uint160(someAddress)));
     }
+
+    function bytesToBech32Bytes(
+        bytes calldata data,
+        uint256 offset
+    ) internal pure returns (bytes memory) {
+        bytes memory bech32Bytes = new bytes(42);
+        for (uint i = 0; i < 42; i++) {
+            bech32Bytes[i] = data[i + offset];
+        }
+
+        return bech32Bytes;
+    }
 }


### PR DESCRIPTION
The function is used to get a Bitcoin address when sending it in an omnichain contract `message`. Used in:

https://github.com/zeta-chain/example-contracts/blob/abb7a57deea783ab17f4c8295ececdf4a239bfc2/omnichain/staking/contracts/Staking.sol#L48-L58