### PR TITLE
feat(pools): display pair contract address

### DIFF
--- a/helpers/pools.ts
+++ b/helpers/pools.ts
@@ -37,16 +37,17 @@ export const getPools = async () => {
     let reservesZETA = "0";
 
     if (pair !== ethers.constants.AddressZero) {
-      const uniswapPairContract = new ethers.Contract(
-        pair,
-        UniswapV2Pair.abi,
-        provider
-      );
-      const reserves = await uniswapPairContract.getReserves();
+      const contract = new ethers.Contract(pair, UniswapV2Pair.abi, provider);
+      const reserves = await contract.getReserves();
       reservesZRC20 = ethers.utils.formatEther(reserves[0]);
       reservesZETA = ethers.utils.formatEther(reserves[1]);
     }
-    return { ...token, reservesZETA, reservesZRC20 };
+    return {
+      ...token,
+      reservesZETA,
+      reservesZRC20,
+      pair,
+    };
   });
 
   const pools = await Promise.all(poolPromises);

--- a/helpers/pools.ts
+++ b/helpers/pools.ts
@@ -44,9 +44,9 @@ export const getPools = async () => {
     }
     return {
       ...token,
+      pair,
       reservesZETA,
       reservesZRC20,
-      pair,
     };
   });
 

--- a/tasks/balances.ts
+++ b/tasks/balances.ts
@@ -62,7 +62,14 @@ const main = async (args: any, hre: HardhatRuntimeEnvironment) => {
     console.log(`
 EVM: ${address} ${btc_address ? `\nBitcoin: ${btc_address}` : ""}
   `);
-    console.table(filteredBalances);
+
+    const output = filteredBalances.reduce((acc: any, item: any) => {
+      const { networkName, ...rest } = item;
+      acc[networkName] = rest;
+      return acc;
+    }, {});
+
+    console.table(output);
   }
 };
 

--- a/tasks/pools.ts
+++ b/tasks/pools.ts
@@ -7,10 +7,10 @@ const main = async (args: any, hre: HardhatRuntimeEnvironment) => {
   const pools = await getPools();
   const poolsFiltered = pools
     .map((n: any) => ({
+      Contract: n.pair,
       ZETA: parseFloat(n.reservesZETA).toFixed(2),
       "ZRC-20": parseFloat(n.reservesZRC20).toFixed(2),
       name: n.asset ? n.name : n.symbol,
-      Contract: n.pair,
     }))
     .sort((a: any, b: any) => {
       if (a.name > b.name) return -1;

--- a/tasks/pools.ts
+++ b/tasks/pools.ts
@@ -10,6 +10,7 @@ const main = async (args: any, hre: HardhatRuntimeEnvironment) => {
       ZETA: parseFloat(n.reservesZETA).toFixed(2),
       "ZRC-20": parseFloat(n.reservesZRC20).toFixed(2),
       name: n.asset ? n.name : n.symbol,
+      Contract: n.pair,
     }))
     .sort((a: any, b: any) => {
       if (a.name > b.name) return -1;

--- a/tasks/pools.ts
+++ b/tasks/pools.ts
@@ -15,7 +15,19 @@ const main = async (args: any, hre: HardhatRuntimeEnvironment) => {
     .sort((a: any, b: any) => {
       if (a.name > b.name) return -1;
     });
-  console.table(poolsFiltered);
+  if (args.json) {
+    console.log(JSON.stringify(poolsFiltered, null, 2));
+  } else {
+    const output = poolsFiltered.reduce((acc: any, item: any) => {
+      const { name, ...rest } = item;
+      acc[name] = rest;
+      return acc;
+    }, {});
+    console.table(output);
+  }
 };
 
-export const poolsTask = task("pools", "", main);
+export const poolsTask = task("pools", "", main).addFlag(
+  "json",
+  "Print the result in JSON format"
+);


### PR DESCRIPTION
* added pair contract address in the output of `pools`:

```
npx hardhat pools    
┌─────────────────────┬──────────┬──────────┬──────────────────────────────────────────────┐
│       (index)       │   ZETA   │  ZRC-20  │                   Contract                   │
├─────────────────────┼──────────┼──────────┼──────────────────────────────────────────────┤
│       tMATIC        │ '240.09' │ '656.67' │ '0x4E77A430a1b8E9055540b2A4aB8364E4E31089ae' │
│        tBTC         │  '0.00'  │ '33.89'  │ '0xaDA812aCAB31a8646d234715E7B9947015f9ab62' │
│        tBNB         │ '884.44' │ '138.58' │ '0x16Ef1b018026E389FDA93c1e993E987CF6E852E7' │
│        gETH         │ '788.26' │ '102.68' │ '0x0C0B35C5eF00d9caD8D2ce65b147ea2A27d526Bc' │
│ USDC-mumbai_testnet │  '0.00'  │  '0.00'  │ '0x0000000000000000000000000000000000000000' │
│ USDC-goerli_testnet │  '0.00'  │  '0.00'  │ '0x0000000000000000000000000000000000000000' │
│  USDC-bsc_testnet   │  '0.00'  │  '0.00'  │ '0x0000000000000000000000000000000000000000' │
└─────────────────────┴──────────┴──────────┴──────────────────────────────────────────────┘
```

* modified `balances` output to show (only the Hardhat command output, `getBalances` and JSON output is the same, so no breaking changes) a table where chain label is the index, so that the table doesn't have a separate integer index:

```
npx hardhat balances                                 

EVM: 0x2cD3D070aE1BD365909dD859d29F387AA96911e1 
Bitcoin: tb1q2dr85d57450xwde6560qyhj7zvzw9895hq25tx
  
┌────────────────┬──────────────┬────────────┬─────────────────────────────────────────────┐
│    (index)     │    native    │    zeta    │                    zrc20                    │
├────────────────┼──────────────┼────────────┼─────────────────────────────────────────────┤
│ mumbai_testnet │  '2050.91'   │  '693.53'  │                                             │
│  zeta_testnet  │  '14503.76'  │     ''     │ '217.00 tMATIC, 5.45 gETH, 0.00100001 tBTC' │
│  bsc_testnet   │   '110.89'   │ '1063.22'  │                                             │
│ goerli_testnet │   '700.66'   │ '62776.05' │                                             │
│  btc_testnet   │ '0.00696175' │            │                                             │
└────────────────┴──────────────┴────────────┴─────────────────────────────────────────────┘
```