### PR TITLE
feat: bytesMemoryToAddress helper function

### DIFF
--- a/contracts/BytesHelperLib.sol
+++ b/contracts/BytesHelperLib.sol
@@ -12,6 +12,19 @@ library BytesHelperLib {
         }
     }
 
+    function bytesMemoryToAddress(
+        bytes memory data,
+        uint256 offset
+    ) internal pure returns (address output) {
+        bytes memory b = new bytes(20);
+        for (uint256 i = 0; i < 20; i++) {
+            b[i] = data[i + offset];
+        }
+        assembly {
+            output := mload(add(b, 20))
+        }
+    }
+
     function bytesToUint32(
         bytes calldata data,
         uint256 offset
@@ -38,18 +51,5 @@ library BytesHelperLib {
         }
 
         return bech32Bytes;
-    }
-
-    function bytesToAddress(
-        bytes memory data,
-        uint256 offset
-    ) internal pure returns (address output) {
-        bytes memory b = new bytes(20);
-        for (uint256 i = 0; i < 20; i++) {
-            b[i] = data[i + offset];
-        }
-        assembly {
-            output := mload(add(b, 20))
-        }
     }
 }

--- a/contracts/BytesHelperLib.sol
+++ b/contracts/BytesHelperLib.sol
@@ -39,4 +39,17 @@ library BytesHelperLib {
 
         return bech32Bytes;
     }
+
+    function bytesToAddress(
+        bytes memory data,
+        uint256 offset
+    ) internal pure returns (address output) {
+        bytes memory b = new bytes(20);
+        for (uint256 i = 0; i < 20; i++) {
+            b[i] = data[i + offset];
+        }
+        assembly {
+            output := mload(add(b, 20))
+        }
+    }
 }


### PR DESCRIPTION
Sometimes this function is useful, for example, when storing recipient's address in memory bytes and then converting it to address when transferring: https://github.com/zeta-chain/example-contracts/pull/96