### PR TITLE
fix(balances): show correct balance for ERC20 tokens

### DIFF
--- a/helpers/balances.ts
+++ b/helpers/balances.ts
@@ -47,7 +47,6 @@ export const getBalances = async (evmAddress: any, btcAddress = null) => {
         chain_id: token.foreign_chain_id,
         coin_type: "ERC20",
         contract: token.asset,
-        decimals: token.decimals,
         symbol: token.symbol,
         zrc20: token.zrc20_contract_address,
       });
@@ -127,8 +126,13 @@ export const getBalances = async (evmAddress: any, btcAddress = null) => {
           ERC20_ABI.abi,
           provider
         );
+        const decimals = await contract.decimals();
         return contract.balanceOf(evmAddress).then((balance: any) => {
-          return { ...token, balance: formatUnits(balance, token.decimals) };
+          return {
+            ...token,
+            balance: formatUnits(balance, decimals),
+            decimals,
+          };
         });
       } else if (isZRC) {
         const rpc = getEndpoints("evm", token.chain_name)[0]?.url;


### PR DESCRIPTION
ERC-20 contract balances where formatted using decimals for ZRC-20, which is not accurate, which meant that balance for USDC on BSC was wrong. This queries ERC-20 contracts for decimals before formatting the balance.