### PR TITLE
feat: `tokens` Hardhat task

### DIFF
--- a/packages/tasks/src/index.ts
+++ b/packages/tasks/src/index.ts
@@ -11,3 +11,4 @@ export { sendBTCTask } from "./sendBTC";
 export { sendZETATask } from "./sendZETA";
 // export { verifyTask } from "./verify";
 export { withdrawTask } from "./withdraw";
+export { tokensTask } from "./tokens";

--- a/packages/tasks/src/index.ts
+++ b/packages/tasks/src/index.ts
@@ -10,5 +10,5 @@ export { poolsTask } from "./pools";
 export { sendBTCTask } from "./sendBTC";
 export { sendZETATask } from "./sendZETA";
 // export { verifyTask } from "./verify";
-export { withdrawTask } from "./withdraw";
 export { tokensTask } from "./tokens";
+export { withdrawTask } from "./withdraw";

--- a/packages/tasks/src/tokens.ts
+++ b/packages/tasks/src/tokens.ts
@@ -1,0 +1,33 @@
+import { task } from "hardhat/config";
+import { ZetaChainClient } from "../../client/src/";
+
+const main = async (args: any, hre: any) => {
+  const client = new ZetaChainClient({
+    network: args.mainnet ? "mainnet" : "testnet",
+  });
+  const tokens = await client.getForeignCoins();
+  const chains = await client.getSupportedChains();
+
+  const tableData = tokens.map((token: any) => {
+    const name = chains.find(
+      (chain: any) => chain.chain_id === token.foreign_chain_id
+    )?.chain_name;
+    return {
+      Chain: name,
+      Symbol: token.symbol,
+      Type: token.coin_type,
+      "ZRC-20 on ZetaChain": token.zrc20_contract_address,
+      "ERC-20 on Connected Chain": token.asset || "",
+    };
+  });
+
+  tableData.sort((a: any, b: any) => a.Chain.localeCompare(b.Chain));
+
+  console.table(tableData);
+};
+
+export const tokensTask = task(
+  "tokens",
+  "Show ZRC-20 address of supported gas and ERC-20 tokens",
+  main
+).addFlag("mainnet", "Run the task on mainnet");

--- a/packages/tasks/src/tokens.ts
+++ b/packages/tasks/src/tokens.ts
@@ -10,9 +10,10 @@ const main = async (args: any, hre: any) => {
   const chains = await client.getSupportedChains();
 
   const tableData = tokens.map((token: any) => {
-    const name = chains.find(
+    const chain = chains.find(
       (chain: any) => chain.chain_id === token.foreign_chain_id
-    )?.chain_name;
+    );
+    const name = chain ? chain.chain_name : "Unsupported Chain";
     return {
       Chain: name,
       "ERC-20 on Connected Chain": token.asset || "",

--- a/packages/tasks/src/tokens.ts
+++ b/packages/tasks/src/tokens.ts
@@ -1,4 +1,5 @@
 import { task } from "hardhat/config";
+
 import { ZetaChainClient } from "../../client/src/";
 
 const main = async (args: any, hre: any) => {
@@ -14,10 +15,10 @@ const main = async (args: any, hre: any) => {
     )?.chain_name;
     return {
       Chain: name,
+      "ERC-20 on Connected Chain": token.asset || "",
       Symbol: token.symbol,
       Type: token.coin_type,
       "ZRC-20 on ZetaChain": token.zrc20_contract_address,
-      "ERC-20 on Connected Chain": token.asset || "",
     };
   });
 


### PR DESCRIPTION
```
npx hardhat tokens
```

This is useful, because some tutorials expect ZRC-20 address as input when interacting. Having the interact task interpret something like "BNB.BSC" and turn it into an address is possible, but then the user needs to know the list of supported tokens. Copying it from the output of the tokens command seems like a good solution.

<img width="1025" alt="Screenshot 2024-03-11 at 15 26 27" src="https://github.com/zeta-chain/toolkit/assets/332151/7b4ab2fa-46b0-4f2d-b554-4bf0aa4ad4d7">
