### PR TITLE
fix: display correct explorer URL on contract deploy

### DIFF
--- a/packages/tasks/templates/omnichain/tasks/deploy.ts.hbs
+++ b/packages/tasks/templates/omnichain/tasks/deploy.ts.hbs
@@ -1,11 +1,13 @@
-import { getAddress } from "@zetachain/protocol-contracts";
+import { getAddress, ParamChainName } from "@zetachain/protocol-contracts";
 import { task } from "hardhat/config";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
 const main = async (args: any, hre: HardhatRuntimeEnvironment) => {
-  if (hre.network.name !== "zeta_testnet") {
+  const network = hre.network.name as ParamChainName;
+
+  if (!/zeta_(testnet|mainnet)/.test(network)) {
     throw new Error(
-      '🚨 Please use the "zeta_testnet" network to deploy to ZetaChain.'
+      '🚨 Please use either "zeta_testnet" or "zeta_mainnet" network to deploy to ZetaChain.'
     );
   }
 
@@ -16,25 +18,27 @@ const main = async (args: any, hre: HardhatRuntimeEnvironment) => {
     );
   }
 
-  const systemContract = getAddress("systemContract", "zeta_testnet");
+  const systemContract = getAddress("systemContract", network);
 
   const factory = await hre.ethers.getContractFactory("{{contractName}}");
   const contract = await factory.deploy(systemContract);
   await contract.deployed();
+
+  const isTestnet = network === "zeta_testnet";
+  const zetascan = isTestnet ? "athens.explorer" : "explorer";
+  const blockscout = isTestnet ? "zetachain-athens-3" : "zetachain";
 
   if (args.json) {
     console.log(JSON.stringify(contract));
   } else {
     console.log(`🔑 Using account: ${signer.address}
 
-🚀 Successfully deployed contract on ZetaChain.
+🚀 Successfully deployed contract on ${network}.
 📜 Contract address: ${contract.address}
-🌍 Explorer: https://athens3.explorer.zetachain.com/address/${contract.address}
+🌍 ZetaScan: https://${zetascan}.zetachain.com/address/${contract.address}
+🌍 Blockcsout: https://${blockscout}.blockscout.com/address/${contract.address}
 `);
   }
 };
 
-task("deploy", "Deploy the contract", main).addFlag(
-  "json",
-  "Output in JSON"
-);
+task("deploy", "Deploy the contract", main).addFlag("json", "Output in JSON");


### PR DESCRIPTION
Display URLs both for ZetaScan and Blockscout both for mainnet and testnet.