### PR TITLE
fix: remove Uniswap V2 token consumer from messaging deploy task

### DIFF
--- a/packages/tasks/templates/messaging/tasks/deploy.ts.hbs
+++ b/packages/tasks/templates/messaging/tasks/deploy.ts.hbs
@@ -2,7 +2,7 @@ import { getAddress } from "@zetachain/protocol-contracts";
 import { ethers } from "ethers";
 import { task, types } from "hardhat/config";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { getSupportedNetworks } from "@zetachain/networks";
+import type { ParamChainName } from "@zetachain/protocol-contracts";
 
 const contractName = "{{contractName}}";
 
@@ -10,7 +10,7 @@ const main = async (args: any, hre: HardhatRuntimeEnvironment) => {
   const networks = args.networks.split(",");
   const contracts: { [key: string]: string } = {};
   await Promise.all(
-    networks.map(async (networkName: string) => {
+    networks.map(async (networkName: ParamChainName) => {
       contracts[networkName] = await deployContract(
         hre,
         networkName,
@@ -21,7 +21,13 @@ const main = async (args: any, hre: HardhatRuntimeEnvironment) => {
   );
 
   for (const source in contracts) {
-    await setInteractors(hre, source, contracts, args.json, args.gasLimit);
+    await setInteractors(
+      hre,
+      source as ParamChainName,
+      contracts,
+      args.json,
+      args.gasLimit
+    );
   }
 
   if (args.json) {
@@ -29,7 +35,10 @@ const main = async (args: any, hre: HardhatRuntimeEnvironment) => {
   }
 };
 
-const initWallet = (hre: HardhatRuntimeEnvironment, networkName: string) => {
+const initWallet = (
+  hre: HardhatRuntimeEnvironment,
+  networkName: ParamChainName
+) => {
   const { url } = hre.config.networks[networkName] as any;
   const provider = new ethers.providers.JsonRpcProvider(url);
   const wallet = new ethers.Wallet(process.env.PRIVATE_KEY as string, provider);
@@ -39,33 +48,26 @@ const initWallet = (hre: HardhatRuntimeEnvironment, networkName: string) => {
 
 const deployContract = async (
   hre: HardhatRuntimeEnvironment,
-  networkName: string,
+  networkName: ParamChainName,
   json: boolean = false,
   gasLimit: number
 ) => {
   const wallet = initWallet(hre, networkName);
 
-  const connector = getAddress("connector", networkName as any);
-  const zetaToken = getAddress("zetaToken", networkName as any);
+  const connector = getAddress("connector", networkName);
+  const zetaToken = getAddress("zetaToken", networkName);
   {{#if arguments.feesNative}}
-  const zetaTokenConsumerUniV2 = getAddress(
-    "zetaTokenConsumerUniV2",
-    networkName as any
-  );
-  const zetaTokenConsumerUniV3 = getAddress(
-    "zetaTokenConsumerUniV3",
-    networkName as any
-  );
+  const zetaTokenConsumer = getAddress("zetaTokenConsumerUniV3", networkName);
   {{/if}}
 
   const { abi, bytecode } = await hre.artifacts.readArtifact(contractName);
   const factory = new ethers.ContractFactory(abi, bytecode, wallet);
-  const contract = await factory.deploy(connector, zetaToken{{#if arguments.feesNative}}, zetaTokenConsumerUniV2 || zetaTokenConsumerUniV3{{/if}}, { gasLimit });
+  const contract = await factory.deploy(connector, zetaToken{{#if arguments.feesNative}}, zetaTokenConsumer{{/if}}, { gasLimit });
 
   await contract.deployed();
   if (!json) {
     console.log(`
-🚀 Successfully deployed contract on ${networkName}.
+🚀 Successfully deployed contract on ${networkName}
 📜 Contract address: ${contract.address}`);
   }
   return contract.address;
@@ -73,7 +75,7 @@ const deployContract = async (
 
 const setInteractors = async (
   hre: HardhatRuntimeEnvironment,
-  source: string,
+  source: ParamChainName,
   contracts: { [key: string]: string },
   json: boolean = false,
   gasLimit: number
@@ -91,7 +93,7 @@ const setInteractors = async (
   for (const counterparty in contracts) {
     if (counterparty === source) continue;
 
-    const counterpartyContract = hre.ethers.utils.solidityPack(
+    const counterpartyContract = ethers.utils.solidityPack(
       ["address"],
       [contracts[counterparty]]
     );
@@ -110,11 +112,6 @@ const setInteractors = async (
 };
 
 task("deploy", "Deploy the contract", main)
-  .addParam(
-    "networks",
-    `Comma separated list of networks to deploy to (e.g. ${getSupportedNetworks(
-      "ccm"
-    )})`
-  )
+  .addParam("networks", "Comma separated list of networks to deploy to")
   .addOptionalParam("gasLimit", "Gas limit", 10000000, types.int)
   .addFlag("json", "Output JSON");


### PR DESCRIPTION
* Removed `zetaTokenConsumerUniV2`, since we only have V3 now
* Use `ParamChainName` instead of `any`
* Use `ethers.utils` instead of `hre.ethers.utils` to avoid type errors