### PR TITLE
feat: Add origin address for MockSystemContract

### DIFF
--- a/contracts/shared/MockSystemContract.sol
+++ b/contracts/shared/MockSystemContract.sol
@@ -99,9 +99,10 @@ contract MockSystemContract is SystemContractErrors {
         uint256 amount,
         bytes calldata message
     ) external {
+        bytes memory originAddress = abi.encode(msg.sender);
         zContext memory context = zContext({
             sender: msg.sender,
-            origin: "",
+            origin: originAddress,
             chainID: chainID
         });
         bool transfer = IZRC20(zrc20).transfer(target, amount);


### PR DESCRIPTION
For certain scenarios, we need to obtain the `origin` address, such as the Staking contract in the Example contract, therefore we need to add an `origin` address parameter.