### PR TITLE
feat(deposit): add ignore check flag

### DIFF
--- a/packages/tasks/src/deposit.ts
+++ b/packages/tasks/src/deposit.ts
@@ -34,26 +34,34 @@ const main = async (args: any, hre: HardhatRuntimeEnvironment) => {
   }
 
   const chain = hre.network.name;
-  if (chain === "zeta_testnet" || chain === "zeta_mainnet") {
-    throw new Error(
-      "the --network defines the chain from which the deposit will be made. The --network value cannot be zeta_testnet or zeta_mainnet"
-    );
-  }
 
-  if (args.recipient) {
-    if (!ethers.utils.isAddress(args.recipient)) {
-      throw new Error("--recipient must be a valid address");
-    }
-  }
-
-  if (message) {
-    const rpc = client.getEndpoint("evm", "zeta_testnet");
-    const provider = new ethers.providers.StaticJsonRpcProvider(rpc);
-    const code = await provider.getCode(args.recipient);
-    if (code === "0x") {
+  if (!args.ignoreChecks) {
+    if (chain === "zeta_testnet" || chain === "zeta_mainnet") {
       throw new Error(
-        "seems like --recipient is an EOA and not a contract on ZetaChain. At the same time the --message is not empty, which indicates this is a 'deposit and call' operation. Please, provide a valid omnichain contract address as the --recipient value"
+        "the --network defines the chain from which the deposit will be made. The --network value cannot be zeta_testnet or zeta_mainnet"
       );
+    }
+
+    if (args.recipient) {
+      if (!ethers.utils.isAddress(args.recipient)) {
+        throw new Error("--recipient must be a valid address");
+      }
+    }
+
+    if (message) {
+      if (!args.recipient) {
+        throw new Error(
+          "--recipient is not specified. Please, provide a valid omnichain contract address on ZetaChain"
+        );
+      }
+      const rpc = client.getEndpoint("evm", "zeta_testnet");
+      const provider = new ethers.providers.StaticJsonRpcProvider(rpc);
+      const code = await provider.getCode(args.recipient);
+      if (code === "0x") {
+        throw new Error(
+          "seems like --recipient is an EOA and not a contract on ZetaChain. At the same time the --message is not empty, which indicates this is a 'deposit and call' operation. Please, provide a valid omnichain contract address as the --recipient value"
+        );
+      }
     }
   }
 
@@ -112,4 +120,5 @@ export const depositTask = task(
   .addOptionalParam("recipient", "Recipient address")
   .addOptionalParam("erc20", "ERC-20 token address")
   .addOptionalParam("message", `Message, like '[["string"], ["hello"]]'`)
-  .addFlag("json", "Output in JSON");
+  .addFlag("json", "Output in JSON")
+  .addFlag("ignoreChecks", "Ignore checks and send the tx");


### PR DESCRIPTION
To allow sending failing transactions, which is useful for demo purposes.

We're using it here:

https://www.zetachain.com/docs/developers/omnichain/transactions/#usdc-to-erc-20-custody-contract-with-a-message

To show an example of a transaction that's failing:

```
npx hardhat deposit --amount 1 --network sepolia_testnet --erc20 0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238 --message '[["string"], ["hello"]]' --recipient 0x4955a3F38ff86ae92A914445099caa8eA2B9bA32 --ignore-checks
```

(just realized that I shouldn't have used it before it's shipped, but alright 😁, it's supposed to fail anyways)