### PR TITLE
feat: update swap helpers to accept system contract as argument

### DIFF
--- a/contracts/SwapHelperLib.sol
+++ b/contracts/SwapHelperLib.sol
@@ -85,17 +85,15 @@ library SwapHelperLib {
             IZRC20(zrc20B).balanceOf(uniswapPool) > 0;
     }
 
-    function _doSwap(
-        address zetaToken,
-        address uniswapV2Factory,
-        address uniswapV2Router,
+    function swapExactTokensForTokens(
+        SystemContract systemContract,
         address zrc20,
         uint256 amount,
         address targetZRC20,
         uint256 minAmountOut
     ) internal returns (uint256) {
         bool existsPairPool = _existsPairPool(
-            uniswapV2Factory,
+            systemContract.uniswapv2FactoryAddress(),
             zrc20,
             targetZRC20
         );
@@ -108,13 +106,17 @@ library SwapHelperLib {
         } else {
             path = new address[](3);
             path[0] = zrc20;
-            path[1] = zetaToken;
+            path[1] = systemContract.wZetaContractAddress();
             path[2] = targetZRC20;
         }
 
-        IZRC20(zrc20).approve(address(uniswapV2Router), amount);
-        uint256[] memory amounts = IUniswapV2Router01(uniswapV2Router)
-            .swapExactTokensForTokens(
+        IZRC20(zrc20).approve(
+            address(systemContract.uniswapv2Router02Address()),
+            amount
+        );
+        uint256[] memory amounts = IUniswapV2Router01(
+            systemContract.uniswapv2Router02Address()
+        ).swapExactTokensForTokens(
                 amount,
                 minAmountOut,
                 path,
@@ -125,16 +127,14 @@ library SwapHelperLib {
     }
 
     function swapTokensForExactTokens(
-        address zetaToken,
-        address uniswapV2Factory,
-        address uniswapV2Router,
+        SystemContract systemContract,
         address zrc20,
         uint256 amount,
         address targetZRC20,
         uint256 amountInMax
     ) internal returns (uint256) {
         bool existsPairPool = _existsPairPool(
-            uniswapV2Factory,
+            systemContract.uniswapv2FactoryAddress(),
             zrc20,
             targetZRC20
         );
@@ -147,13 +147,17 @@ library SwapHelperLib {
         } else {
             path = new address[](3);
             path[0] = zrc20;
-            path[1] = zetaToken;
+            path[1] = systemContract.wZetaContractAddress();
             path[2] = targetZRC20;
         }
 
-        IZRC20(zrc20).approve(address(uniswapV2Router), amountInMax);
-        uint256[] memory amounts = IUniswapV2Router01(uniswapV2Router)
-            .swapTokensForExactTokens(
+        IZRC20(zrc20).approve(
+            address(systemContract.uniswapv2Router02Address()),
+            amountInMax
+        );
+        uint256[] memory amounts = IUniswapV2Router01(
+            systemContract.uniswapv2Router02Address()
+        ).swapTokensForExactTokens(
                 amount,
                 amountInMax,
                 path,

--- a/packages/tasks/templates/omnichain/contracts/{{contractName}}.sol.hbs
+++ b/packages/tasks/templates/omnichain/contracts/{{contractName}}.sol.hbs
@@ -5,7 +5,7 @@ import "@zetachain/protocol-contracts/contracts/zevm/SystemContract.sol";
 import "@zetachain/protocol-contracts/contracts/zevm/interfaces/zContract.sol";
 
 contract {{contractName}} is zContract {
-    SystemContract public immutable systemContract;
+    SystemContract public systemContract;
 
     constructor(address systemContractAddress) {
         systemContract = SystemContract(systemContractAddress);


### PR DESCRIPTION
* Rename `_doSwap` to `swapExactTokensForTokens`
* Pass the system contract directly to swap function to avoid repetitive code in tutorials
* Removed `immutable` from the system contract var so that it can be used to instantiate variables in the constructor (throws an error otherwise)

Passing the system contract directly will allow us to do something like this:

```solidity
// SPDX-License-Identifier: MIT
pragma solidity 0.8.7;

import "@zetachain/protocol-contracts/contracts/zevm/SystemContract.sol";
import "@zetachain/protocol-contracts/contracts/zevm/interfaces/zContract.sol";
import "@zetachain/toolkit/contracts/SwapHelperLib.sol";
import "@zetachain/toolkit/contracts/BytesHelperLib.sol";
import "@openzeppelin/contracts/token/ERC20/IERC20.sol";

contract Swap is zContract {
    SystemContract public systemContract;

    uint256 constant BITCOIN = 18332;

    constructor(address systemContractAddress) {
        systemContract = SystemContract(systemContractAddress);
    }

    modifier onlySystem() {
        require(
            msg.sender == address(systemContract),
            "Only system contract can call this function"
        );
        _;
    }

    function onCrossChainCall(
        zContext calldata context,
        address zrc20,
        uint256 amount,
        bytes calldata message
    ) external virtual override onlySystem {
        address targetToken;
        bytes memory recipient;

        if (context.chainID == BITCOIN) {
            targetToken = BytesHelperLib.bytesToAddress(message, 0);
            recipient = abi.encodePacked(
                BytesHelperLib.bytesToAddress(message, 20)
            );
        } else {
            (address targetTokenAddress, bytes memory recipientAddress) = abi
                .decode(message, (address, bytes));
            targetTokenAddress = targetToken;
            recipientAddress = recipient;
        }

        bool toZeta = targetToken == systemContract.wZetaContractAddress();
        uint256 inputForGas;
        address gasZRC20;
        uint256 gasFee;

        if (!toZeta) {
            (gasZRC20, gasFee) = IZRC20(targetToken).withdrawGasFee();

            inputForGas = SwapHelperLib.swapTokensForExactTokens(
                systemContract,
                zrc20,
                gasFee,
                gasZRC20,
                amount
            );
        }

        uint256 outputAmount = SwapHelperLib._doSwap(
            systemContract,
            zrc20,
            toZeta ? amount : amount - inputForGas,
            targetToken,
            0
        );

        if (!toZeta) {
            IZRC20(gasZRC20).approve(targetToken, gasFee);
            IZRC20(targetToken).withdraw(recipient, outputAmount);
        }
    }
}
```

Instead of:

```solidity
// SPDX-License-Identifier: MIT
pragma solidity 0.8.7;

import "@zetachain/protocol-contracts/contracts/zevm/SystemContract.sol";
import "@zetachain/protocol-contracts/contracts/zevm/interfaces/zContract.sol";
import "@zetachain/toolkit/contracts/SwapHelperLib.sol";
import "@zetachain/toolkit/contracts/BytesHelperLib.sol";
import "@openzeppelin/contracts/token/ERC20/IERC20.sol";

contract Swap is zContract {
    SystemContract public systemContract;
    address public wzeta; // No longer needed
    address public factory; // No longer needed
    address public router; // No longer needed

    uint256 constant BITCOIN = 18332;

    constructor(address systemContractAddress) {
        systemContract = SystemContract(systemContractAddress);
        wzeta = systemContract.wZetaContractAddress(); // No longer needed
        factory = systemContract.uniswapv2FactoryAddress(); // No longer needed
        router = systemContract.uniswapv2Router02Address(); // No longer needed
    }

    modifier onlySystem() {
        require(
            msg.sender == address(systemContract),
            "Only system contract can call this function"
        );
        _;
    }

    function onCrossChainCall(
        zContext calldata context,
        address zrc20,
        uint256 amount,
        bytes calldata message
    ) external virtual override onlySystem {
        address targetTokenAddress;
        bytes memory recipientAddress;

        if (context.chainID == BITCOIN) {
            targetTokenAddress = BytesHelperLib.bytesToAddress(message, 0);
            recipientAddress = abi.encodePacked(
                BytesHelperLib.bytesToAddress(message, 20)
            );
        } else {
            (address targetToken, bytes memory recipient) = abi.decode(
                message,
                (address, bytes)
            );
            targetTokenAddress = targetToken;
            recipientAddress = recipient;
        }

        bool isTargetZeta = targetTokenAddress == wzeta;
        uint256 inputForGas;
        address gasZRC20;
        uint256 gasFee;

        if (!isTargetZeta) {
            (gasZRC20, gasFee) = IZRC20(targetTokenAddress).withdrawGasFee();

            inputForGas = SwapHelperLib.swapTokensForExactTokens(
                wzeta, // Replaced with system contract
                factory, // No longer needed
                router, // No longer needed
                zrc20,
                gasFee,
                gasZRC20,
                amount
            );
        }

        uint256 outputAmount = SwapHelperLib._doSwap(
            wzeta, // Replaced with system contract
            factory, // No longer needed
            router, // No longer needed
            zrc20,
            isTargetZeta ? amount : amount - inputForGas,
            targetTokenAddress,
            0
        );

        if (!isTargetZeta) {
            IZRC20(gasZRC20).approve(targetTokenAddress, gasFee);
            IZRC20(targetTokenAddress).withdraw(recipientAddress, outputAmount);
        }
    }
}
```

Which saves us 10 lines of code and makes tutorials more readable.