### PR TITLE
OnlySystem modifier

### DIFF
--- a/contracts/OnlySystem.sol
+++ b/contracts/OnlySystem.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.7;
+
+contract OnlySystem {
+    error OnlySystemContract(string);
+
+    modifier onlySystem(address systemContract) {
+        if (msg.sender != address(systemContract)) {
+            revert OnlySystemContract(
+                "Only system contract can call this function"
+            );
+        }
+        _;
+    }
+}


### PR DESCRIPTION
`OnlySystem` modifier which can be imported into contracts and used like so:

```solidity
// SPDX-License-Identifier: MIT
pragma solidity 0.8.7;

import "@zetachain/protocol-contracts/contracts/zevm/SystemContract.sol";
import "@zetachain/protocol-contracts/contracts/zevm/interfaces/zContract.sol";
import "@zetachain/toolkit/contracts/SwapHelperLib.sol";
import "@zetachain/toolkit/contracts/BytesHelperLib.sol";
import "@zetachain/toolkit/contracts/OnlySystem.sol";

contract Swap is zContract, OnlySystem {
    SystemContract public systemContract;

    constructor(address systemContractAddress) {
        systemContract = SystemContract(systemContractAddress);
    }

    function onCrossChainCall(
        zContext calldata context,
        address zrc20,
        uint256 amount,
        bytes calldata message
    ) external virtual override onlySystem(address(systemContract)) {
    //...
}
```