### PR TITLE
refactor(messaging): fetch zeta token address from connector

### DIFF
--- a/packages/tasks/templates/messaging/contracts/{{contractName}}.sol.hbs
+++ b/packages/tasks/templates/messaging/contracts/{{contractName}}.sol.hbs
@@ -5,6 +5,7 @@ import "@openzeppelin/contracts/interfaces/IERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@zetachain/protocol-contracts/contracts/evm/tools/ZetaInteractor.sol";
 import "@zetachain/protocol-contracts/contracts/evm/interfaces/ZetaInterfaces.sol";
+import "@zetachain/protocol-contracts/contracts/evm/ZetaConnector.base.sol";
 {{#unless arguments.feesNative}}
 import "@zetachain/protocol-contracts/contracts/evm/Zeta.eth.sol";
 {{/unless}}
@@ -24,8 +25,8 @@ contract {{contractName}} is ZetaInteractor{{#if arguments.argsListNotEmpty}}, Z
     {{/if}}
     IERC20 internal immutable _zetaToken;
 
-    constructor(address connectorAddress, address zetaTokenAddress{{#if arguments.feesNative}}, address zetaConsumerAddress{{/if}}) ZetaInteractor(connectorAddress) {
-        _zetaToken = IERC20(zetaTokenAddress);
+    constructor(address connectorAddress{{#if arguments.feesNative}}, address zetaConsumerAddress{{/if}}) ZetaInteractor(connectorAddress) {
+        _zetaToken = IERC20(ZetaConnectorBase(connectorAddress).zetaToken());
         {{#if arguments.feesNative}}
         _zetaConsumer = ZetaTokenConsumer(zetaConsumerAddress);
         {{/if}}

--- a/packages/tasks/templates/messaging/tasks/deploy.ts.hbs
+++ b/packages/tasks/templates/messaging/tasks/deploy.ts.hbs
@@ -55,14 +55,13 @@ const deployContract = async (
   const wallet = initWallet(hre, networkName);
 
   const connector = getAddress("connector", networkName);
-  const zetaToken = getAddress("zetaToken", networkName);
   {{#if arguments.feesNative}}
   const zetaTokenConsumer = getAddress("zetaTokenConsumerUniV3", networkName);
   {{/if}}
 
   const { abi, bytecode } = await hre.artifacts.readArtifact(contractName);
   const factory = new ethers.ContractFactory(abi, bytecode, wallet);
-  const contract = await factory.deploy(connector, zetaToken{{#if arguments.feesNative}}, zetaTokenConsumer{{/if}}, { gasLimit });
+  const contract = await factory.deploy(connector{{#if arguments.feesNative}}, zetaTokenConsumer{{/if}}, { gasLimit });
 
   await contract.deployed();
   if (!json) {


### PR DESCRIPTION
Simplifies the messaging contract constructor by removing ZETA token address param: it is now fetched from the connector.

Before:

```solidity
contract MyContract is ZetaInteractor, ZetaReceiver {
    ZetaTokenConsumer private immutable _zetaConsumer;
    IERC20 internal immutable _zetaToken;

    constructor(address connectorAddress, address zetaTokenAddress, address zetaConsumerAddress) ZetaInteractor(connectorAddress) {
        _zetaToken = IERC20(zetaTokenAddress);
        _zetaConsumer = ZetaTokenConsumer(zetaConsumerAddress);
    }
```

After:

```solidity
import "@zetachain/protocol-contracts/contracts/evm/ZetaConnector.base.sol";

contract MyContract is ZetaInteractor, ZetaReceiver {    
    ZetaTokenConsumer private immutable _zetaConsumer;
    IERC20 internal immutable _zetaToken;

    constructor(address connectorAddress, address zetaConsumerAddress) ZetaInteractor(connectorAddress) {
        _zetaToken = IERC20(ZetaConnectorBase(connectorAddress).zetaToken());
        _zetaConsumer = ZetaTokenConsumer(zetaConsumerAddress);
    }
    //...
}
```