### PR TITLE
feat: generate omnichain contracts with new OnlySystem by default

### DIFF
--- a/contracts/OnlySystem.sol
+++ b/contracts/OnlySystem.sol
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
+import "@zetachain/protocol-contracts/contracts/zevm/SystemContract.sol";
+
 contract OnlySystem {
     error OnlySystemContract(string);
 
-    modifier onlySystem(address systemContract) {
+    modifier onlySystem(SystemContract systemContract) {
         if (msg.sender != address(systemContract)) {
             revert OnlySystemContract(
                 "Only system contract can call this function"

--- a/packages/tasks/templates/omnichain/contracts/{{contractName}}.sol.hbs
+++ b/packages/tasks/templates/omnichain/contracts/{{contractName}}.sol.hbs
@@ -3,20 +3,13 @@ pragma solidity 0.8.7;
 
 import "@zetachain/protocol-contracts/contracts/zevm/SystemContract.sol";
 import "@zetachain/protocol-contracts/contracts/zevm/interfaces/zContract.sol";
+import "@zetachain/toolkit/contracts/OnlySystem.sol";
 
-contract {{contractName}} is zContract {
+contract {{contractName}} is zContract, OnlySystem {
     SystemContract public systemContract;
 
     constructor(address systemContractAddress) {
         systemContract = SystemContract(systemContractAddress);
-    }
-
-    modifier onlySystem() {
-        require(
-            msg.sender == address(systemContract),
-            "Only system contract can call this function"
-        );
-        _;
     }
 
     function onCrossChainCall(
@@ -24,7 +17,7 @@ contract {{contractName}} is zContract {
         address zrc20,
         uint256 amount,
         bytes calldata message
-    ) external virtual override onlySystem {
+    ) external virtual override onlySystem(systemContract) {
         {{#if arguments.pairsWithDataLocation}}
         ({{#each arguments.pairsWithDataLocation}}{{#if @index}}, {{/if}}{{this.[1]}} {{this.[0]}}{{/each}}) = abi.decode(
             message,


### PR DESCRIPTION
* `OnlySystem` modifier accepts a system contract (not just address)
* Omnichain template now comes with `OnlySystem` by default

New default template:

```solidity
// SPDX-License-Identifier: MIT
pragma solidity 0.8.7;

import "@zetachain/protocol-contracts/contracts/zevm/SystemContract.sol";
import "@zetachain/protocol-contracts/contracts/zevm/interfaces/zContract.sol";
import "@zetachain/toolkit/contracts/OnlySystem.sol";

contract Swap is zContract, OnlySystem {
    SystemContract public systemContract;

    constructor(address systemContractAddress) {
        systemContract = SystemContract(systemContractAddress);
    }

    function onCrossChainCall(
        zContext calldata context,
        address zrc20,
        uint256 amount,
        bytes calldata message
    ) external virtual override onlySystem(systemContract) {
        (address targetToken, string memory recipient) = abi.decode(
            message,
            (address, string)
        );
        // TODO: implement the logic
    }
}
```