### PR TITLE
refactor: update liquidity amount

### DIFF
--- a/packages/test/src/helpers.ts
+++ b/packages/test/src/helpers.ts
@@ -82,7 +82,7 @@ const addZetaEthLiquidity = async (
     block.timestamp + 360,
     {
       gasLimit: 10_000_000,
-      value: parseUnits("1000"),
+      value: parseUnits("10"),
     }
   );
   await tx2.wait();


### PR DESCRIPTION
Reduce the amount of added liquidity to prevent scripts from running with too much ETH and not being able to complete tests.