### PR TITLE
fix: set ZETA token address from constructor argument

### DIFF
--- a/packages/tasks/templates/messaging/contracts/{{contractName}}.sol.hbs
+++ b/packages/tasks/templates/messaging/contracts/{{contractName}}.sol.hbs
@@ -5,7 +5,6 @@ import "@openzeppelin/contracts/interfaces/IERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@zetachain/protocol-contracts/contracts/evm/tools/ZetaInteractor.sol";
 import "@zetachain/protocol-contracts/contracts/evm/interfaces/ZetaInterfaces.sol";
-import "@zetachain/protocol-contracts/contracts/evm/ZetaConnector.base.sol";
 {{#unless arguments.feesNative}}
 import "@zetachain/protocol-contracts/contracts/evm/Zeta.eth.sol";
 {{/unless}}
@@ -25,8 +24,8 @@ contract {{contractName}} is ZetaInteractor{{#if arguments.argsListNotEmpty}}, Z
     {{/if}}
     IERC20 internal immutable _zetaToken;
 
-    constructor(address connectorAddress{{#if arguments.feesNative}}, address zetaConsumerAddress{{/if}}) ZetaInteractor(connectorAddress) {
-        _zetaToken = IERC20(ZetaConnectorBase(connectorAddress).zetaToken());
+    constructor(address connectorAddress, address zetaTokenAddress{{#if arguments.feesNative}}, address zetaConsumerAddress{{/if}}) ZetaInteractor(connectorAddress) {
+        _zetaToken = IERC20(zetaTokenAddress);
         {{#if arguments.feesNative}}
         _zetaConsumer = ZetaTokenConsumer(zetaConsumerAddress);
         {{/if}}

--- a/packages/tasks/templates/messaging/tasks/deploy.ts.hbs
+++ b/packages/tasks/templates/messaging/tasks/deploy.ts.hbs
@@ -55,13 +55,14 @@ const deployContract = async (
   const wallet = initWallet(hre, networkName);
 
   const connector = getAddress("connector", networkName);
+  const zetaToken = getAddress("zetaToken", networkName);
   {{#if arguments.feesNative}}
   const zetaTokenConsumer = getAddress("zetaTokenConsumerUniV3", networkName);
   {{/if}}
 
   const { abi, bytecode } = await hre.artifacts.readArtifact(contractName);
   const factory = new ethers.ContractFactory(abi, bytecode, wallet);
-  const contract = await factory.deploy(connector{{#if arguments.feesNative}}, zetaTokenConsumer{{/if}}, { gasLimit });
+  const contract = await factory.deploy(connector, zetaToken{{#if arguments.feesNative}}, zetaTokenConsumer{{/if}}, { gasLimit });
 
   await contract.deployed();
   if (!json) {


### PR DESCRIPTION
Reverting back to setting ZETA token address explicitly through a constructor argument, instead of reading it from the connector, because connector on Ethereum and BNB has ZETA token address stored in `zetaToken`, and connector on ZetaChain has ZETA token address stored in `WZETA` (https://github.com/zeta-chain/protocol-contracts/issues/158) Thus, we can't use the same constructor to read ZETA token address, so we have to revert back to passing it explicitly.

Tested messaging to and from ZetaChain, it works.

https://zetachain-athens-3.blockscout.com/address/0xf401596Ff974F379cE85F727D2F2dc441a319e06?tab=logs

https://sepolia.etherscan.io/address/0x08b6C291B45949A2ab646C1969493913F1771DFc#events