### PR TITLE
fix: getFees should skip querying CCM fees if chain doesn't support it

### DIFF
--- a/packages/client/src/getFees.ts
+++ b/packages/client/src/getFees.ts
@@ -43,6 +43,9 @@ const fetchCCMFees = async function (
   }
   const url = `${API}/zeta-chain/crosschain/convertGasToZeta?chainId=${chainID}&gasLimit=${gas}`;
   const response = await fetch(url);
+  if (!response.ok) {
+    return;
+  }
   const data = await response.json();
   const gasFee = ethers.BigNumber.from(data.outboundGasInZeta);
   const protocolFee = ethers.BigNumber.from(data.protocolFeeInZeta);


### PR DESCRIPTION
Polygon Amoy has been added as a supported chain, but CCM hasn't been enabled for it, so `getFees` was throwing an error.