### PR TITLE
chore: update protocol contracts to v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@uniswap/v2-periphery": "^1.1.0-beta.0",
     "@zetachain/faucet-cli": "^4.0.1",
     "@zetachain/networks": "^8.0.0",
-    "@zetachain/protocol-contracts": "7.0.0",
+    "@zetachain/protocol-contracts": "8.0.0-rc1",
     "axios": "^1.4.0",
     "bech32": "^2.0.0",
     "bip39": "^3.1.0",

--- a/packages/client/src/getFees.ts
+++ b/packages/client/src/getFees.ts
@@ -12,7 +12,12 @@ const fetchZEVMFees = async function (
 ) {
   const provider = new ethers.providers.StaticJsonRpcProvider(rpcUrl);
   const contract = new ethers.Contract(zrc20.address, ZRC20.abi, provider);
-  const [, withdrawGasFee] = await contract.withdrawGasFee();
+  let withdrawGasFee;
+  try {
+    [, withdrawGasFee] = await contract.withdrawGasFee();
+  } catch (e) {
+    return;
+  }
   const gasFee = ethers.BigNumber.from(withdrawGasFee);
   const protocolFee = ethers.BigNumber.from(await contract.PROTOCOL_FLAT_FEE());
   const gasToken = foreignCoins.find((c: any) => {
@@ -90,7 +95,7 @@ export const getFees = async function (this: ZetaChainClient, gas: Number) {
       try {
         const rpcUrl = this.getEndpoint("evm", `zeta_${this.network}`);
         const fee = await fetchZEVMFees(zrc20, rpcUrl, foreignCoins);
-        fees.omnichain.push(fee);
+        if (fee) fees.omnichain.push(fee);
       } catch (err) {
         console.log(err);
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1767,10 +1767,10 @@
   dependencies:
     dotenv "^16.1.4"
 
-"@zetachain/protocol-contracts@7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@zetachain/protocol-contracts/-/protocol-contracts-7.0.0.tgz#20eb6c62d805d7470408ccdff0e3614684bca174"
-  integrity sha512-8JTNFZxVZYmDtAXJIEr+tkakuML12X42Fya4bJ1NkfWiVMkcSej92BSTl/35qYtHdjY7vXy9uMrfXEqfw5rsPw==
+"@zetachain/protocol-contracts@8.0.0-rc1":
+  version "8.0.0-rc1"
+  resolved "https://registry.yarnpkg.com/@zetachain/protocol-contracts/-/protocol-contracts-8.0.0-rc1.tgz#34df589c1b56df77f2695b37bd8a4b79df1787b1"
+  integrity sha512-VpgbQtVUxy4XYFb0P9UN9nQZkhQ+fr3Bg7A5SqZJCH3fi8QELSn6qaVSwATn+mXdnSMD2uXWSnyy/ANXFqedmw==
 
 abbrev@1:
   version "1.1.1"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for fetching `withdrawGasFee` to ensure the application returns early in case of an error and adds the fee only if it is valid.
  
- **Chores**
  - Updated the version of `@zetachain/protocol-contracts` from `7.0.0` to `8.0.0-rc1`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->