### PR TITLE
fix: deposit ERC-20

### DIFF
--- a/contracts/BytesHelperLib.sol
+++ b/contracts/BytesHelperLib.sol
@@ -3,7 +3,7 @@ pragma solidity =0.8.7;
 
 library BytesHelperLib {
     error OffsetOutOfBounds();
-    
+
     function bytesToAddress(
         bytes calldata data,
         uint256 offset
@@ -51,11 +51,10 @@ library BytesHelperLib {
         return bech32Bytes;
     }
 
-    function bytesToBool(bytes calldata data, uint256 offset)
-        internal
-        pure
-        returns (bool)
-    {
+    function bytesToBool(
+        bytes calldata data,
+        uint256 offset
+    ) internal pure returns (bool) {
         if (offset >= data.length) {
             revert OffsetOutOfBounds();
         }

--- a/packages/client/src/deposit.ts
+++ b/packages/client/src/deposit.ts
@@ -35,11 +35,11 @@ export const deposit = async function (
     erc20,
     message,
   }: {
-    chain: string;
     amount: string;
-    recipient: string;
+    chain: string;
     erc20?: string;
     message?: [string[], string[]];
+    recipient: string;
   }
 ) {
   let signer;
@@ -98,9 +98,9 @@ export const deposit = async function (
       throw new Error(`No TSS contract found for ${chain} chain.`);
     }
     const tx = {
+      data,
       to: tss,
       value: ethers.utils.parseUnits(amount, 18),
-      data,
     };
     return await signer.sendTransaction(tx);
   }

--- a/packages/client/src/deposit.ts
+++ b/packages/client/src/deposit.ts
@@ -56,10 +56,10 @@ export const deposit = async function (
   if (message && !recipient) {
     throw new Error("Please, provide a valid contract address as recipient.");
   }
-  const abiCoder = ethers.utils.defaultAbiCoder;
+
   const recipientHex = ethers.utils.hexZeroPad(recipient, 20);
   const encodedMessage = message
-    ? abiCoder.encode(message[0], message[1]).slice(2)
+    ? ethers.utils.defaultAbiCoder.encode(message[0], message[1]).slice(2)
     : "";
   const data = recipientHex + encodedMessage;
 

--- a/packages/client/src/deposit.ts
+++ b/packages/client/src/deposit.ts
@@ -56,7 +56,6 @@ export const deposit = async function (
   if (message && !recipient) {
     throw new Error("Please, provide a valid contract address as recipient.");
   }
-
   const abiCoder = ethers.utils.defaultAbiCoder;
   const recipientHex = ethers.utils.hexZeroPad(recipient, 20);
   const encodedMessage = message

--- a/packages/tasks/src/deposit.ts
+++ b/packages/tasks/src/deposit.ts
@@ -115,7 +115,7 @@ const main = async (args: any, hre: HardhatRuntimeEnvironment) => {
 Networks:    ${chain} → zeta_testnet
 Amount sent: ${amount} ${symbol || ""}
 Sender:      ${signer.address}
-Recipient:   ${args.recipient || signer.address}`);
+Recipient:   ${args.recipient}`);
     if (message) {
       console.log(`Message:     ${args.message}`);
     }
@@ -148,7 +148,7 @@ export const depositTask = task(
   main
 )
   .addParam("amount", "Amount tokens to send")
-  .addOptionalParam("recipient", "Recipient address")
+  .addParam("recipient", "Recipient address")
   .addOptionalParam("erc20", "ERC-20 token address")
   .addOptionalParam("message", `Message, like '[["string"], ["hello"]]'`)
   .addFlag("json", "Output in JSON")


### PR DESCRIPTION
Fix `deposit` to always include a recipient address in the message when depositing ERC-20, because of https://github.com/zeta-chain/node/issues/2435

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved handling of deposit transactions, including updated handling of recipient and message parameters and refined data encoding.

- **Refactor**
  - Renamed `options.sourceChain` to `options.chain`.
  - Changed `recipient` from optional to required parameter.
  - Updated internal data composition and transaction object handling for deposits.

- **Bug Fixes**
  - Adjusted the `bytesToBool` function formatting and parameter alignment for better clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->