### PR TITLE
refactor(getBalances): Use multicall3 to reduce numer of RPC calls

### DIFF
--- a/packages/client/src/getBalances.ts
+++ b/packages/client/src/getBalances.ts
@@ -138,11 +138,10 @@ export const getBalances = async function (
         multicallContexts[token.chain_name] = [];
       }
       multicallContexts[token.chain_name].push({
-        target: token.contract,
         callData: new ethers.utils.Interface(
-        target: token.contract,
           token.coin_type === "ERC20" ? ERC20_ABI.abi : ZRC20.abi
         ).encodeFunctionData("balanceOf", [evmAddress]),
+        target: token.contract,
       });
     }
   });

--- a/packages/client/src/getBalances.ts
+++ b/packages/client/src/getBalances.ts
@@ -140,6 +140,7 @@ export const getBalances = async function (
       multicallContexts[token.chain_name].push({
         target: token.contract,
         callData: new ethers.utils.Interface(
+        target: token.contract,
           token.coin_type === "ERC20" ? ERC20_ABI.abi : ZRC20.abi
         ).encodeFunctionData("balanceOf", [evmAddress]),
       });

--- a/packages/tasks/src/account.ts
+++ b/packages/tasks/src/account.ts
@@ -70,7 +70,7 @@ export const main = async (args: any, hre: HardhatRuntimeEnvironment) => {
 🔑 Private key: ${pk}`);
   mnemonic && console.log(`🔐 Mnemonic phrase: ${mnemonic.phrase}`);
   console.log(`😃 EVM address: ${address}
-😃 Bitcoin address: ${bitcoinAddress(pk)}
+😃 Bitcoin address: ${bitcoinAddress(pk, "testnet")}
 😃 Bech32 address: ${hexToBech32Address(address, "zeta")}
 `);
 

--- a/packages/tasks/src/balances.ts
+++ b/packages/tasks/src/balances.ts
@@ -47,7 +47,7 @@ const main = async (args: any, hre: HardhatRuntimeEnvironment) => {
     evmAddress = args.address;
   } else if (pk) {
     evmAddress = new ethers.Wallet(pk).address;
-    btcAddress = bitcoinAddress(pk);
+    btcAddress = bitcoinAddress(pk, args.mainnet ? "mainnet" : "testnet");
   } else {
     spinner.stop();
     console.error(walletError + balancesError);

--- a/packages/tasks/src/bitcoinAddress.ts
+++ b/packages/tasks/src/bitcoinAddress.ts
@@ -2,15 +2,16 @@ import * as bitcoin from "bitcoinjs-lib";
 import ECPairFactory from "ecpair";
 import * as ecc from "tiny-secp256k1";
 
-export const bitcoinAddress = (pk: string) => {
-  const TESTNET = bitcoin.networks.testnet;
+export const bitcoinAddress = (pk: string, network: "testnet" | "mainnet") => {
+  const bitcoinNetwork =
+    network === "testnet" ? bitcoin.networks.testnet : bitcoin.networks.bitcoin;
 
   const ECPair = ECPairFactory(ecc);
   const key = ECPair.fromPrivateKey(Buffer.from(pk, "hex"), {
-    network: TESTNET,
+    network: bitcoinNetwork,
   });
   const { address } = bitcoin.payments.p2wpkh({
-    network: TESTNET,
+    network: bitcoinNetwork,
     pubkey: key.publicKey,
   });
   if (!address) throw new Error("Unable to generate bitcoin address");

--- a/packages/tasks/src/bitcoinAddress.ts
+++ b/packages/tasks/src/bitcoinAddress.ts
@@ -2,7 +2,7 @@ import * as bitcoin from "bitcoinjs-lib";
 import ECPairFactory from "ecpair";
 import * as ecc from "tiny-secp256k1";
 
-export const bitcoinAddress = (pk: string, network: "testnet" | "mainnet") => {
+export const bitcoinAddress = (pk: string, network: "mainnet" | "testnet") => {
   const bitcoinNetwork =
     network === "testnet" ? bitcoin.networks.testnet : bitcoin.networks.bitcoin;
 


### PR DESCRIPTION
* use multicall3
* fix BTC balance fetching with `--mainnet`

Before, 160 requests:

<img width="1263" alt="Screenshot 2024-07-14 at 17 07 41" src="https://github.com/user-attachments/assets/42d18041-824c-46e8-b8df-75939e09b2f0">

After, 76 requests:

<img width="1263" alt="Screenshot 2024-07-14 at 17 06 00" src="https://github.com/user-attachments/assets/aee6424f-ba40-47ea-b295-1b3fdbba72ed">

Seems like a solid 2x performance improvement. We can now use public RPC endpoints for the component library and not be rate-limited.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced balance retrieval with multicall functionality for more efficient token balance updates.
  - Bitcoin address generation now supports specifying network type (`testnet` or `mainnet`).

- **Improvements**
  - Streamlined token balance retrieval process by grouping tokens by chain and using multicall with fallback for individual calls.
  - Improved clarity in specifying network type for Bitcoin address generation based on environment (testnet or mainnet).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->