### PR TITLE
fix: mainnet flag in hardhat cctx

### DIFF
--- a/packages/tasks/src/cctx.ts
+++ b/packages/tasks/src/cctx.ts
@@ -35,4 +35,4 @@ export const cctxTask = task(
 )
   .addPositionalParam("tx", "Hash of an inbound or a cross-chain transaction")
   .addFlag("json", "Output as JSON")
-  .addOptionalParam("type", "Testnet or mainnet", "testnet");
+  .addFlag("mainnet", "Run the task on mainnet");


### PR DESCRIPTION
The task expected boolean, but the argument was passed as a string, so it always defaulted to testnet.

```
 npx hardhat cctx 0xd8d4f6e45057f355ea657def7026aa9c7496f6ad37550b1cd541c2374b1c3851 --mainnet
✓ CCTXs on ZetaChain found.

✓ 0xe031d59358c10b9275c00a955fffaf9fc70bc0cbe501e7c97c6b96a990f347df: 56 → 7000: OutboundMined (Remote omnichain contract call completed)
✓ 0x9902d0752b34d0a9e5ef17bd5ff27dbcfe6a0bcac9879d3d6c8b202fae3d9b6d: 7000 → 137: OutboundMined (ZRC20 withdrawal event setting to pending outbound directly : Outbound succeeded, mined)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new boolean flag for the `cctxTask` function to specify if the task should run on the mainnet, simplifying the command-line interface.
  
- **Changes**
	- Removed the previous optional parameter for network type, enhancing clarity in usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->