### PR TITLE
chore: remove `@zetachain/addresses` from `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "@typescript-eslint/eslint-plugin": "^5.59.9",
     "@typescript-eslint/parser": "^5.59.9",
     "@uniswap/v2-core": "^1.0.1",
-    "@zetachain/addresses": "^0.0.10",
     "chai": "^4.2.0",
     "cpx": "^1.5.0",
     "eslint": "^8.42.0",


### PR DESCRIPTION
It's not being used anywhere, so we should remove this package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed the dependency on `@zetachain/addresses`, streamlining project dependencies.
	- Minor formatting change for improved file standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->