### PR TITLE
fix: remove tx option defaults

### DIFF
--- a/packages/tasks/src/evmDepositAndCall.ts
+++ b/packages/tasks/src/evmDepositAndCall.ts
@@ -51,18 +51,8 @@ task("evm-deposit-and-call", "Deposit tokens", evmDepositAndCall)
     "0x0000000000000000000000000000000000000000",
     types.string
   )
-  .addOptionalParam(
-    "gasPrice",
-    "The gas price for the transaction",
-    50000000000,
-    types.int
-  )
-  .addOptionalParam(
-    "gasLimit",
-    "The gas limit for the transaction",
-    7000000,
-    types.int
-  )
+  .addOptionalParam("gasPrice", "The gas price for the transaction")
+  .addOptionalParam("gasLimit", "The gas limit for the transaction")
   .addOptionalParam(
     "onRevertGasLimit",
     "The gas limit for the revert transaction",


### PR DESCRIPTION
Each chain has its own gas limit and price and having defaults prevents hardhat from inheriting these values from config. This resulted in tx broadcasting being stuck.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `evmDepositAndCall` task to allow for more flexible gas settings by removing default values for `gasPrice` and `gasLimit`. 

- **Bug Fixes**
	- Enhanced the handling of optional parameters for improved clarity and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->