### PR TITLE
Fix: Solana Web3.js Library Supply Chain Attack

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@openzeppelin/contracts": "^5.0.2",
     "@openzeppelin/contracts-upgradeable": "^5.0.2",
     "@solana/wallet-adapter-react": "^0.15.35",
-    "@solana/web3.js": "^1.95.3",
+    "@solana/web3.js": "^1.95.5",
     "@uniswap/v2-periphery": "^1.1.0-beta.0",
     "@zetachain/faucet-cli": "^4.1.1",
     "@zetachain/networks": "v10.0.0",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@openzeppelin/contracts": "^5.0.2",
     "@openzeppelin/contracts-upgradeable": "^5.0.2",
     "@solana/wallet-adapter-react": "^0.15.35",
-    "@solana/web3.js": "^1.95.5",
+    "@solana/web3.js": "^1.95.8",
     "@uniswap/v2-periphery": "^1.1.0-beta.0",
     "@zetachain/faucet-cli": "^4.1.1",
     "@zetachain/networks": "v10.0.0",


### PR DESCRIPTION
Fix: Solana Web3.js Library Supply Chain Attack 

A recent supply chain attack compromised versions 1.95.6 and 1.95.7 of the @solana/web3.js JavaScript library, leading to the theft of approximately $160,000 in assets. The malicious code exfiltrated private keys, affecting developers and applications that integrated these versions. 

References:

[Solana Web3.js Library Compromised in Targeted Supply Chain Attack](https://decrypt.co/294742/solana-web3-js-library-compromised-in-targeted-supply-chain-attack)
[Supply Chain Attack Detected in Solana's web3.js Library](https://socket.dev/blog/supply-chain-attack-solana-web3-js-library)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Updated the `@solana/web3.js` dependency version to enhance performance and stability.

- **Chores**
	- Incremented the patch version of `@solana/web3.js` from `^1.95.3` to `^1.95.8` for improved stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->