### PR TITLE
fix: solana withdraw

### DIFF
--- a/packages/client/src/zetachainWithdraw.ts
+++ b/packages/client/src/zetachainWithdraw.ts
@@ -55,11 +55,11 @@ export const zetachainWithdraw = async function (
       utils.toUtf8Bytes(args.revertOptions.revertMessage)
     ),
   };
-
   const zrc20 = new ethers.Contract(args.zrc20, ZRC20ABI.abi, signer);
   const decimals = await zrc20.decimals();
   const value = utils.parseUnits(args.amount, decimals);
   const [gasZRC20, gasFee] = await zrc20.withdrawGasFee();
+
   if (args.zrc20 === gasZRC20) {
     const approveGasAndWithdraw = await zrc20.approve(
       gatewayZetaChainAddress,
@@ -89,7 +89,7 @@ export const zetachainWithdraw = async function (
   const method =
     "withdraw(bytes,uint256,address,(address,bool,address,bytes,uint256))";
   const tx = await gateway[method](
-    utils.hexlify(args.receiver),
+    utils.toUtf8Bytes(args.receiver),
     value,
     args.zrc20,
     revertOptions,


### PR DESCRIPTION
Solana:

```
npx hardhat zetachain-withdraw --amount 0.1 --zrc20 0x4955a3F38ff86ae92A914445099caa8eA2B9bA32 --receiver EnGmXjAuSd4j4ru3cSjUoBe2sT4gfNwKZ9jfoxjGs4ad --gateway-zeta-chain 0x6c533f7fe93fae114d0954697069df33c9b74fd7 --network zeta_testnet
```

https://zetachain-athens.blockpi.network/lcd/v1/public/zeta-chain/crosschain/inboundHashToCctxData/0x47c6c081c0cd5d84bde462462dcdfd21df76851fd0e32a3ef6231c6d6008878d

EVM:

```
npx hardhat zetachain-withdraw --amount 0.1 --zrc20 0x777915D031d1e8144c90D025C594b3b8Bf07a08d --receiver 0x4955a3F38ff86ae92A914445099caa8eA2B9bA32 --gateway-zeta-chain 0x6c533f7fe93fae114d0954697069df33c9b74fd7 --network zeta_testnet
```

https://zetachain-athens.blockpi.network/lcd/v1/public/zeta-chain/crosschain/inboundHashToCctxData/0x2d81a1220bb8ffb2b6a12721a7c14136cb720a7a867e26a98e0870434c95825a