### PR TITLE
docs: replace link to the template with a link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,8 @@ utility functions that make it easier to build with ZetaChain.
 
 ## Building a dApp on ZetaChain
 
-If you're looking to build a dapp on ZetaChain, we recommend using the Hardhat
-[template](https://github.com/zeta-chain/template). This template has all the
-toolkit featured imported, so you don't need to install this package manually.
+If you're looking to build a dapp on ZetaChain, we recommend checking out
+[the tutorials section](https://www.zetachain.com/docs/developers/tutorials/hello/) in ZetaChain docs.
 
 ## Prerequisites
 


### PR DESCRIPTION
The template repo has been deprecated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the developer guidance for building dApps on ZetaChain by recommending users consult the official tutorials for a more hands-on introduction.
	- Maintained the overall structure and core content of the guide, ensuring continuity in prerequisites and installation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->