### PR TITLE
Update sendBTC.ts

### DIFF
--- a/packages/tasks/src/sendBTC.ts
+++ b/packages/tasks/src/sendBTC.ts
@@ -102,10 +102,10 @@ const main = async (args: any, hre: HardhatRuntimeEnvironment) => {
   const TESTNET = bitcoin.networks.testnet;
   const API = getEndpoints("blockcypher", "btc_testnet")[0].url;
 
-  const pk = process.env.PRIVATE_KEY as any;
+  const pk = process.env.BTC_PRIVATE_KEY as any;
   if (!pk) {
     throw new Error(
-      "Cannot find a private key, please set the PRIVATE_KEY env variable"
+      "Cannot find a private key, please set the BTC_PRIVATE_KEY env variable"
     );
   }
 
@@ -168,7 +168,7 @@ Memo:            ${args.memo}
 };
 
 export const sendBTCTask = task(
-  "send-btc",
+  "btc-deposit-and-call",
   "Deposit Bitcoin to and call contracts on ZetaChain",
   main
 )


### PR DESCRIPTION
I've made to changes!

chore: changed PRIVATE_KEY to BTC_PRIVATE_KEY
chore: CLI command from "send-btc" to "btc-deposit-and-call"

After use this cli npx hardhat account --save it will create the .env on vercel, with 4 fields...
PRIVATE_KEY,EVM_PRIVATE_KEY,BTC_PRIVATE_KEY,SOLANA_PRIVATE_KEY

Since Hardhat already creates a dedicated BTC_PRIVATE_KEY variable, it makes sense to use it instead of relying on PRIVATE_KEY for Bitcoin. This change ensures that the correct private key is used when interacting with the Bitcoin network.

This is especially useful for users who have a different private key for Bitcoin, as is my case.