### PR TITLE
fix: getBalance fetching from supported chains

### DIFF
--- a/packages/client/src/getBalances.ts
+++ b/packages/client/src/getBalances.ts
@@ -200,9 +200,6 @@ export const getBalances = async function (
               const balance = BigInt(
                 ethers.utils.defaultAbiCoder.decode(["uint256"], data)[0]
               );
-              // const formattedBalance = (
-              //   balance / BigInt(10 ** token.decimals)
-              // ).toString();
               const formattedBalance = formatUnits(balance, token.decimals);
               balances.push({ ...token, balance: formattedBalance });
             }

--- a/packages/client/src/getBalances.ts
+++ b/packages/client/src/getBalances.ts
@@ -138,7 +138,7 @@ export const getBalances = async function (
       const ticker = token.symbol.split("-")[0];
       const chain_name = supportedChains.find(
         (c: any) => c.chain_id === token.chain_id.toString()
-      )?.chain_name;
+      )?.name;
       return {
         ...token,
         chain_name,
@@ -200,9 +200,10 @@ export const getBalances = async function (
               const balance = BigInt(
                 ethers.utils.defaultAbiCoder.decode(["uint256"], data)[0]
               );
-              const formattedBalance = (
-                balance / BigInt(10 ** token.decimals)
-              ).toString();
+              // const formattedBalance = (
+              //   balance / BigInt(10 ** token.decimals)
+              // ).toString();
+              const formattedBalance = formatUnits(balance, token.decimals);
               balances.push({ ...token, balance: formattedBalance });
             }
           });


### PR DESCRIPTION
* Switch from `chain_name` to `name` when fetching chains from [supported chains endpoint](https://zetachain.blockpi.network/lcd/v1/public/zeta-chain/observer/supportedChains) (`chain_name` has been deprecated)
* Format ZRC-20 balances correctly using `formatUnits`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated how token chain information is retrieved for improved consistency.
	- Enhanced token balance formatting using a standardized approach to ensure reliable display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->