### PR TITLE
feat: Add support for onAbort address in revert options

### DIFF
--- a/packages/client/src/evmCall.ts
+++ b/packages/client/src/evmCall.ts
@@ -48,16 +48,8 @@ export const evmCall = async function (
   ) as GatewayContract;
 
   const revertOptions = {
-    abortAddress: args.revertOptions.abortAddress,
-    callOnRevert: args.revertOptions.callOnRevert,
-    onRevertGasLimit: args.revertOptions.onRevertGasLimit,
-    revertAddress: args.revertOptions.revertAddress,
+    ...args.revertOptions,
     revertMessage: toHexString(args.revertOptions.revertMessage),
-  };
-
-  const txOptions = {
-    gasLimit: args.txOptions.gasLimit,
-    gasPrice: args.txOptions.gasPrice,
   };
 
   const abiCoder = AbiCoder.defaultAbiCoder();
@@ -73,7 +65,7 @@ export const evmCall = async function (
     args.receiver,
     encodedParameters,
     revertOptions,
-    txOptions
+    args.txOptions
   );
 
   return tx;

--- a/packages/client/src/evmCall.ts
+++ b/packages/client/src/evmCall.ts
@@ -47,6 +47,19 @@ export const evmCall = async function (
     signer
   ) as GatewayContract;
 
+  const revertOptions = {
+    abortAddress: args.revertOptions.abortAddress,
+    callOnRevert: args.revertOptions.callOnRevert,
+    onRevertGasLimit: args.revertOptions.onRevertGasLimit,
+    revertAddress: args.revertOptions.revertAddress,
+    revertMessage: toHexString(args.revertOptions.revertMessage),
+  };
+
+  const txOptions = {
+    gasLimit: args.txOptions.gasLimit,
+    gasPrice: args.txOptions.gasPrice,
+  };
+
   const abiCoder = AbiCoder.defaultAbiCoder();
   const encodedParameters = abiCoder.encode(args.types, args.values);
 
@@ -59,17 +72,8 @@ export const evmCall = async function (
   const tx = await gatewayCallFunction(
     args.receiver,
     encodedParameters,
-    {
-      abortAddress: args.revertOptions.abortAddress,
-      callOnRevert: args.revertOptions.callOnRevert,
-      onRevertGasLimit: args.revertOptions.onRevertGasLimit,
-      revertAddress: args.revertOptions.revertAddress,
-      revertMessage: toHexString(args.revertOptions.revertMessage),
-    },
-    {
-      gasLimit: args.txOptions.gasLimit,
-      gasPrice: args.txOptions.gasPrice,
-    }
+    revertOptions,
+    txOptions
   );
 
   return tx;

--- a/packages/client/src/evmCall.ts
+++ b/packages/client/src/evmCall.ts
@@ -60,7 +60,7 @@ export const evmCall = async function (
     args.receiver,
     encodedParameters,
     {
-      abortAddress: "0x0000000000000000000000000000000000000000", // not used
+      abortAddress: args.revertOptions.abortAddress,
       callOnRevert: args.revertOptions.callOnRevert,
       onRevertGasLimit: args.revertOptions.onRevertGasLimit,
       revertAddress: args.revertOptions.revertAddress,

--- a/packages/client/src/evmDeposit.ts
+++ b/packages/client/src/evmDeposit.ts
@@ -49,11 +49,10 @@ export const evmDeposit = async function (
   ) as GatewayContract;
 
   const revertOptions = {
-    abortAddress: "0x0000000000000000000000000000000000000000", // not used
+    abortAddress: args.revertOptions.abortAddress,
     callOnRevert: args.revertOptions.callOnRevert,
     onRevertGasLimit: args.revertOptions.onRevertGasLimit,
     revertAddress: args.revertOptions.revertAddress,
-    // not used
     revertMessage: toHexString(args.revertOptions.revertMessage),
   };
 

--- a/packages/client/src/evmDeposit.ts
+++ b/packages/client/src/evmDeposit.ts
@@ -49,17 +49,10 @@ export const evmDeposit = async function (
   ) as GatewayContract;
 
   const revertOptions = {
-    abortAddress: args.revertOptions.abortAddress,
-    callOnRevert: args.revertOptions.callOnRevert,
-    onRevertGasLimit: args.revertOptions.onRevertGasLimit,
-    revertAddress: args.revertOptions.revertAddress,
+    ...args.revertOptions,
     revertMessage: toHexString(args.revertOptions.revertMessage),
   };
 
-  const txOptions = {
-    gasLimit: args.txOptions.gasLimit,
-    gasPrice: args.txOptions.gasPrice,
-  };
   let tx;
   if (args.erc20) {
     const erc20Contract = new ethers.Contract(
@@ -86,7 +79,7 @@ export const evmDeposit = async function (
       value,
       args.erc20,
       revertOptions,
-      txOptions
+      args.txOptions
     );
   } else {
     const depositAbiSignature =
@@ -97,7 +90,7 @@ export const evmDeposit = async function (
     const value = ethers.parseEther(args.amount);
 
     tx = await gatewayDepositFunction(args.receiver, revertOptions, {
-      ...txOptions,
+      ...args.txOptions,
       value,
     });
   }

--- a/packages/client/src/evmDepositAndCall.ts
+++ b/packages/client/src/evmDepositAndCall.ts
@@ -58,7 +58,6 @@ export const evmDepositAndCall = async function (
     callOnRevert: args.revertOptions.callOnRevert,
     onRevertGasLimit: args.revertOptions.onRevertGasLimit,
     revertAddress: args.revertOptions.revertAddress,
-    // not used
     revertMessage: toHexString(args.revertOptions.revertMessage),
   };
 

--- a/packages/client/src/evmDepositAndCall.ts
+++ b/packages/client/src/evmDepositAndCall.ts
@@ -54,7 +54,7 @@ export const evmDepositAndCall = async function (
   ) as GatewayContract;
 
   const revertOptions = {
-    abortAddress: "0x0000000000000000000000000000000000000000", // not used
+    abortAddress: args.revertOptions.abortAddress,
     callOnRevert: args.revertOptions.callOnRevert,
     onRevertGasLimit: args.revertOptions.onRevertGasLimit,
     revertAddress: args.revertOptions.revertAddress,

--- a/packages/client/src/evmDepositAndCall.ts
+++ b/packages/client/src/evmDepositAndCall.ts
@@ -54,16 +54,8 @@ export const evmDepositAndCall = async function (
   ) as GatewayContract;
 
   const revertOptions = {
-    abortAddress: args.revertOptions.abortAddress,
-    callOnRevert: args.revertOptions.callOnRevert,
-    onRevertGasLimit: args.revertOptions.onRevertGasLimit,
-    revertAddress: args.revertOptions.revertAddress,
+    ...args.revertOptions,
     revertMessage: toHexString(args.revertOptions.revertMessage),
-  };
-
-  const txOptions = {
-    gasLimit: args.txOptions.gasLimit,
-    gasPrice: args.txOptions.gasPrice,
   };
 
   const abiCoder = AbiCoder.defaultAbiCoder();
@@ -96,7 +88,7 @@ export const evmDepositAndCall = async function (
       args.erc20,
       encodedParameters,
       revertOptions,
-      txOptions
+      args.txOptions
     );
   } else {
     const depositAndCallAbiSignature =
@@ -111,7 +103,7 @@ export const evmDepositAndCall = async function (
       encodedParameters,
       revertOptions,
       {
-        ...txOptions,
+        ...args.txOptions,
         value,
       }
     );

--- a/packages/client/src/zetachainCall.ts
+++ b/packages/client/src/zetachainCall.ts
@@ -60,7 +60,7 @@ export const zetachainCall = async function (
   ) as GatewayContract;
 
   const revertOptions = {
-    abortAddress: "0x0000000000000000000000000000000000000000", // not used
+    abortAddress: args.revertOptions.abortAddress,
     callOnRevert: args.revertOptions.callOnRevert,
     onRevertGasLimit: args.revertOptions.onRevertGasLimit,
     revertAddress: args.revertOptions.revertAddress,

--- a/packages/client/src/zetachainCall.ts
+++ b/packages/client/src/zetachainCall.ts
@@ -60,10 +60,7 @@ export const zetachainCall = async function (
   ) as GatewayContract;
 
   const revertOptions = {
-    abortAddress: args.revertOptions.abortAddress,
-    callOnRevert: args.revertOptions.callOnRevert,
-    onRevertGasLimit: args.revertOptions.onRevertGasLimit,
-    revertAddress: args.revertOptions.revertAddress,
+    ...args.revertOptions,
     revertMessage: toHexString(args.revertOptions.revertMessage),
   };
 

--- a/packages/client/src/zetachainWithdraw.ts
+++ b/packages/client/src/zetachainWithdraw.ts
@@ -53,7 +53,7 @@ export const zetachainWithdraw = async function (
   ) as GatewayContract;
 
   const revertOptions = {
-    abortAddress: "0x0000000000000000000000000000000000000000",
+    abortAddress: args.revertOptions.abortAddress,
     callOnRevert: args.revertOptions.callOnRevert,
     onRevertGasLimit: args.revertOptions.onRevertGasLimit,
     revertAddress: args.revertOptions.revertAddress,

--- a/packages/client/src/zetachainWithdraw.ts
+++ b/packages/client/src/zetachainWithdraw.ts
@@ -53,12 +53,10 @@ export const zetachainWithdraw = async function (
   ) as GatewayContract;
 
   const revertOptions = {
-    abortAddress: args.revertOptions.abortAddress,
-    callOnRevert: args.revertOptions.callOnRevert,
-    onRevertGasLimit: args.revertOptions.onRevertGasLimit,
-    revertAddress: args.revertOptions.revertAddress,
+    ...args.revertOptions,
     revertMessage: toHexString(args.revertOptions.revertMessage),
   };
+
   const zrc20 = new ethers.Contract(
     args.zrc20,
     ZRC20ABI.abi,

--- a/packages/client/src/zetachainWithdrawAndCall.ts
+++ b/packages/client/src/zetachainWithdrawAndCall.ts
@@ -63,10 +63,7 @@ export const zetachainWithdrawAndCall = async function (
   ) as GatewayContract;
 
   const revertOptions = {
-    abortAddress: args.revertOptions.abortAddress,
-    callOnRevert: args.revertOptions.callOnRevert,
-    onRevertGasLimit: args.revertOptions.onRevertGasLimit,
-    revertAddress: args.revertOptions.revertAddress,
+    ...args.revertOptions,
     revertMessage: toHexString(args.revertOptions.revertMessage),
   };
 

--- a/packages/client/src/zetachainWithdrawAndCall.ts
+++ b/packages/client/src/zetachainWithdrawAndCall.ts
@@ -63,7 +63,7 @@ export const zetachainWithdrawAndCall = async function (
   ) as GatewayContract;
 
   const revertOptions = {
-    abortAddress: "0x0000000000000000000000000000000000000000",
+    abortAddress: args.revertOptions.abortAddress,
     callOnRevert: args.revertOptions.callOnRevert,
     onRevertGasLimit: args.revertOptions.onRevertGasLimit,
     revertAddress: args.revertOptions.revertAddress,

--- a/packages/tasks/src/evmCall.ts
+++ b/packages/tasks/src/evmCall.ts
@@ -20,6 +20,7 @@ const evmCallArgsSchema = z.object({
   onRevertGasLimit: bigNumberStringSchema,
   receiver: evmAddressSchema,
   revertAddress: evmAddressSchema,
+  abortAddress: evmAddressSchema,
   revertMessage: z.string(),
   types: validJsonStringSchema,
   values: z.array(z.string()).min(1, "At least one value is required"),
@@ -50,6 +51,7 @@ export const evmCall = async (
         onRevertGasLimit: parsedArgs.onRevertGasLimit,
         revertAddress: parsedArgs.revertAddress,
         revertMessage: parsedArgs.revertMessage,
+        abortAddress: parsedArgs.abortAddress,
       },
       txOptions: {
         gasLimit: parsedArgs.gasLimit,
@@ -73,6 +75,11 @@ task("evm-call", "Call a universal app", evmCall)
   .addOptionalParam(
     "revertAddress",
     "Revert address",
+    "0x0000000000000000000000000000000000000000"
+  )
+  .addOptionalParam(
+    "abortAddress",
+    "Abort address",
     "0x0000000000000000000000000000000000000000"
   )
   .addOptionalParam(

--- a/packages/tasks/src/evmCall.ts
+++ b/packages/tasks/src/evmCall.ts
@@ -13,6 +13,7 @@ import { parseAbiValues } from "../../../utils/parseAbiValues";
 import { ZetaChainClient } from "../../client/src/";
 
 const evmCallArgsSchema = z.object({
+  abortAddress: evmAddressSchema,
   callOnRevert: z.boolean().optional(),
   gasLimit: bigNumberStringSchema,
   gasPrice: bigNumberStringSchema,
@@ -20,7 +21,6 @@ const evmCallArgsSchema = z.object({
   onRevertGasLimit: bigNumberStringSchema,
   receiver: evmAddressSchema,
   revertAddress: evmAddressSchema,
-  abortAddress: evmAddressSchema,
   revertMessage: z.string(),
   types: validJsonStringSchema,
   values: z.array(z.string()).min(1, "At least one value is required"),
@@ -47,11 +47,11 @@ export const evmCall = async (
       gatewayEvm: parsedArgs.gatewayEvm,
       receiver: parsedArgs.receiver,
       revertOptions: {
+        abortAddress: parsedArgs.abortAddress,
         callOnRevert: parsedArgs.callOnRevert || false,
         onRevertGasLimit: parsedArgs.onRevertGasLimit,
         revertAddress: parsedArgs.revertAddress,
         revertMessage: parsedArgs.revertMessage,
-        abortAddress: parsedArgs.abortAddress,
       },
       txOptions: {
         gasLimit: parsedArgs.gasLimit,

--- a/packages/tasks/src/evmDeposit.ts
+++ b/packages/tasks/src/evmDeposit.ts
@@ -19,6 +19,7 @@ const evmDepositArgsSchema = z.object({
   onRevertGasLimit: bigNumberStringSchema,
   receiver: evmAddressSchema,
   revertAddress: evmAddressSchema,
+  abortAddress: evmAddressSchema,
   revertMessage: z.string(),
 });
 
@@ -44,6 +45,7 @@ export const evmDeposit = async (
         onRevertGasLimit: parsedArgs.onRevertGasLimit,
         revertAddress: parsedArgs.revertAddress,
         revertMessage: parsedArgs.revertMessage,
+        abortAddress: parsedArgs.abortAddress,
       },
       txOptions: {
         gasLimit: parsedArgs.gasLimit,
@@ -69,6 +71,11 @@ task("evm-deposit", "Deposit tokens", evmDeposit)
     "Revert address",
     "0x0000000000000000000000000000000000000000",
     types.string
+  )
+  .addOptionalParam(
+    "abortAddress",
+    "Abort address",
+    "0x0000000000000000000000000000000000000000"
   )
   .addOptionalParam(
     "gasPrice",

--- a/packages/tasks/src/evmDeposit.ts
+++ b/packages/tasks/src/evmDeposit.ts
@@ -10,6 +10,7 @@ import { validateTaskArgs } from "../../../utils";
 import { ZetaChainClient } from "../../client/src/";
 
 const evmDepositArgsSchema = z.object({
+  abortAddress: evmAddressSchema,
   amount: z.string(),
   callOnRevert: z.boolean().optional(),
   erc20: z.string().optional(),
@@ -19,7 +20,6 @@ const evmDepositArgsSchema = z.object({
   onRevertGasLimit: bigNumberStringSchema,
   receiver: evmAddressSchema,
   revertAddress: evmAddressSchema,
-  abortAddress: evmAddressSchema,
   revertMessage: z.string(),
 });
 
@@ -41,11 +41,11 @@ export const evmDeposit = async (
       gatewayEvm: parsedArgs.gatewayEvm,
       receiver: parsedArgs.receiver,
       revertOptions: {
+        abortAddress: parsedArgs.abortAddress,
         callOnRevert: Boolean(parsedArgs.callOnRevert),
         onRevertGasLimit: parsedArgs.onRevertGasLimit,
         revertAddress: parsedArgs.revertAddress,
         revertMessage: parsedArgs.revertMessage,
-        abortAddress: parsedArgs.abortAddress,
       },
       txOptions: {
         gasLimit: parsedArgs.gasLimit,

--- a/packages/tasks/src/evmDepositAndCall.ts
+++ b/packages/tasks/src/evmDepositAndCall.ts
@@ -13,6 +13,7 @@ import { parseAbiValues } from "../../../utils/parseAbiValues";
 import { ZetaChainClient } from "../../client/src/";
 
 const evmDepositAndCallArgsSchema = z.object({
+  abortAddress: evmAddressSchema,
   amount: z.string(),
   callOnRevert: z.boolean().optional(),
   erc20: z.string().optional(),
@@ -23,7 +24,6 @@ const evmDepositAndCallArgsSchema = z.object({
   receiver: evmAddressSchema,
   revertAddress: evmAddressSchema,
   revertMessage: z.string(),
-  abortAddress: evmAddressSchema,
   types: validJsonStringSchema,
   values: z.array(z.string()).min(1, "At least one value is required"),
 });
@@ -49,11 +49,11 @@ export const evmDepositAndCall = async (
       gatewayEvm: parsedArgs.gatewayEvm,
       receiver: parsedArgs.receiver,
       revertOptions: {
+        abortAddress: parsedArgs.abortAddress,
         callOnRevert: parsedArgs.callOnRevert || false,
         onRevertGasLimit: parsedArgs.onRevertGasLimit,
         revertAddress: parsedArgs.revertAddress,
         revertMessage: parsedArgs.revertMessage,
-        abortAddress: parsedArgs.abortAddress,
       },
       txOptions: {
         gasLimit: parsedArgs.gasLimit,

--- a/packages/tasks/src/evmDepositAndCall.ts
+++ b/packages/tasks/src/evmDepositAndCall.ts
@@ -23,6 +23,7 @@ const evmDepositAndCallArgsSchema = z.object({
   receiver: evmAddressSchema,
   revertAddress: evmAddressSchema,
   revertMessage: z.string(),
+  abortAddress: evmAddressSchema,
   types: validJsonStringSchema,
   values: z.array(z.string()).min(1, "At least one value is required"),
 });
@@ -52,6 +53,7 @@ export const evmDepositAndCall = async (
         onRevertGasLimit: parsedArgs.onRevertGasLimit,
         revertAddress: parsedArgs.revertAddress,
         revertMessage: parsedArgs.revertMessage,
+        abortAddress: parsedArgs.abortAddress,
       },
       txOptions: {
         gasLimit: parsedArgs.gasLimit,
@@ -78,6 +80,11 @@ task("evm-deposit-and-call", "Deposit tokens", evmDepositAndCall)
     "Revert address",
     "0x0000000000000000000000000000000000000000",
     types.string
+  )
+  .addOptionalParam(
+    "abortAddress",
+    "Abort address",
+    "0x0000000000000000000000000000000000000000"
   )
   .addOptionalParam(
     "gasPrice",

--- a/packages/tasks/src/zetachainCall.ts
+++ b/packages/tasks/src/zetachainCall.ts
@@ -13,6 +13,7 @@ import { parseAbiValues } from "../../../utils/parseAbiValues";
 import { ZetaChainClient } from "../../client/src/";
 
 const zetachainCallArgsSchema = z.object({
+  abortAddress: evmAddressSchema,
   callOnRevert: z.boolean().optional(),
   callOptionsGasLimit: bigNumberStringSchema,
   callOptionsIsArbitraryCall: z.boolean().optional(),
@@ -21,7 +22,6 @@ const zetachainCallArgsSchema = z.object({
   onRevertGasLimit: bigNumberStringSchema,
   receiver: z.string(),
   revertAddress: evmAddressSchema,
-  abortAddress: evmAddressSchema,
   revertMessage: z.string(),
   txOptionsGasLimit: bigNumberStringSchema,
   txOptionsGasPrice: bigNumberStringSchema,
@@ -57,11 +57,11 @@ export const zetachainCall = async (
       gatewayZetaChain: parsedArgs.gatewayZetaChain,
       receiver: parsedArgs.receiver,
       revertOptions: {
+        abortAddress: parsedArgs.abortAddress,
         callOnRevert: parsedArgs.callOnRevert || false,
         onRevertGasLimit: parsedArgs.onRevertGasLimit,
         revertAddress: parsedArgs.revertAddress,
         revertMessage: parsedArgs.revertMessage,
-        abortAddress: parsedArgs.abortAddress,
       },
       txOptions: {
         gasLimit: parsedArgs.txOptionsGasLimit,

--- a/packages/tasks/src/zetachainCall.ts
+++ b/packages/tasks/src/zetachainCall.ts
@@ -20,7 +20,8 @@ const zetachainCallArgsSchema = z.object({
   gatewayZetaChain: evmAddressSchema.optional(),
   onRevertGasLimit: bigNumberStringSchema,
   receiver: z.string(),
-  revertAddress: z.string(),
+  revertAddress: evmAddressSchema,
+  abortAddress: evmAddressSchema,
   revertMessage: z.string(),
   txOptionsGasLimit: bigNumberStringSchema,
   txOptionsGasPrice: bigNumberStringSchema,
@@ -60,6 +61,7 @@ export const zetachainCall = async (
         onRevertGasLimit: parsedArgs.onRevertGasLimit,
         revertAddress: parsedArgs.revertAddress,
         revertMessage: parsedArgs.revertMessage,
+        abortAddress: parsedArgs.abortAddress,
       },
       txOptions: {
         gasLimit: parsedArgs.txOptionsGasLimit,
@@ -86,6 +88,11 @@ task("zetachain-call", "Call a contract on a connected chain", zetachainCall)
   .addOptionalParam(
     "revertAddress",
     "Revert address",
+    "0x0000000000000000000000000000000000000000"
+  )
+  .addOptionalParam(
+    "abortAddress",
+    "Abort address",
     "0x0000000000000000000000000000000000000000"
   )
   .addOptionalParam(

--- a/packages/tasks/src/zetachainWithdraw.ts
+++ b/packages/tasks/src/zetachainWithdraw.ts
@@ -10,7 +10,7 @@ import { validateTaskArgs } from "../../../utils";
 import { ZetaChainClient } from "../../client/src/";
 
 const zetachainWithdrawArgsSchema = z.object({
-  abortAddress: z.string(),
+  abortAddress: evmAddressSchema,
   amount: z.string(),
   callOnRevert: z.boolean().optional(),
   gatewayZetaChain: evmAddressSchema.optional(),

--- a/packages/tasks/src/zetachainWithdraw.ts
+++ b/packages/tasks/src/zetachainWithdraw.ts
@@ -10,6 +10,7 @@ import { validateTaskArgs } from "../../../utils";
 import { ZetaChainClient } from "../../client/src/";
 
 const zetachainWithdrawArgsSchema = z.object({
+  abortAddress: z.string(),
   amount: z.string(),
   callOnRevert: z.boolean().optional(),
   gatewayZetaChain: evmAddressSchema.optional(),
@@ -17,7 +18,6 @@ const zetachainWithdrawArgsSchema = z.object({
   receiver: z.string(),
   revertAddress: z.string(),
   revertMessage: z.string(),
-  abortAddress: z.string(),
   txOptionsGasLimit: bigNumberStringSchema,
   txOptionsGasPrice: bigNumberStringSchema,
   zrc20: z.string(),
@@ -40,11 +40,11 @@ export const zetachainWithdraw = async (
       gatewayZetaChain: parsedArgs.gatewayZetaChain,
       receiver: parsedArgs.receiver,
       revertOptions: {
+        abortAddress: parsedArgs.abortAddress,
         callOnRevert: parsedArgs.callOnRevert || false,
         onRevertGasLimit: parsedArgs.onRevertGasLimit,
         revertAddress: parsedArgs.revertAddress,
         revertMessage: parsedArgs.revertMessage,
-        abortAddress: parsedArgs.abortAddress,
       },
       txOptions: {
         gasLimit: parsedArgs.txOptionsGasLimit,

--- a/packages/tasks/src/zetachainWithdraw.ts
+++ b/packages/tasks/src/zetachainWithdraw.ts
@@ -17,6 +17,7 @@ const zetachainWithdrawArgsSchema = z.object({
   receiver: z.string(),
   revertAddress: z.string(),
   revertMessage: z.string(),
+  abortAddress: z.string(),
   txOptionsGasLimit: bigNumberStringSchema,
   txOptionsGasPrice: bigNumberStringSchema,
   zrc20: z.string(),
@@ -43,6 +44,7 @@ export const zetachainWithdraw = async (
         onRevertGasLimit: parsedArgs.onRevertGasLimit,
         revertAddress: parsedArgs.revertAddress,
         revertMessage: parsedArgs.revertMessage,
+        abortAddress: parsedArgs.abortAddress,
       },
       txOptions: {
         gasLimit: parsedArgs.txOptionsGasLimit,
@@ -68,6 +70,11 @@ task("zetachain-withdraw", "Withdraw tokens from ZetaChain", zetachainWithdraw)
   .addOptionalParam(
     "revertAddress",
     "Revert address",
+    "0x0000000000000000000000000000000000000000"
+  )
+  .addOptionalParam(
+    "abortAddress",
+    "Abort address",
     "0x0000000000000000000000000000000000000000"
   )
   .addOptionalParam(

--- a/packages/tasks/src/zetachainWithdrawAndCall.ts
+++ b/packages/tasks/src/zetachainWithdrawAndCall.ts
@@ -23,7 +23,7 @@ const zetachainWithdrawAndCallArgsSchema = z.object({
   onRevertGasLimit: bigNumberStringSchema,
   receiver: z.string(),
   revertAddress: evmAddressSchema,
-  revertMessage: evmAddressSchema,
+  revertMessage: z.string(),
   txOptionsGasLimit: bigNumberStringSchema,
   txOptionsGasPrice: bigNumberStringSchema,
   types: validJsonStringSchema,

--- a/packages/tasks/src/zetachainWithdrawAndCall.ts
+++ b/packages/tasks/src/zetachainWithdrawAndCall.ts
@@ -13,6 +13,7 @@ import { parseAbiValues } from "../../../utils/parseAbiValues";
 import { ZetaChainClient } from "../../client/src/";
 
 const zetachainWithdrawAndCallArgsSchema = z.object({
+  abortAddress: evmAddressSchema,
   amount: z.string(),
   callOnRevert: z.boolean().optional(),
   callOptionsGasLimit: bigNumberStringSchema,
@@ -63,6 +64,7 @@ export const zetachainWithdrawAndCall = async (
         onRevertGasLimit: parsedArgs.onRevertGasLimit,
         revertAddress: parsedArgs.revertAddress,
         revertMessage: parsedArgs.revertMessage,
+        abortAddress: parsedArgs.abortAddress,
       },
       txOptions: {
         gasLimit: parsedArgs.txOptionsGasLimit,

--- a/packages/tasks/src/zetachainWithdrawAndCall.ts
+++ b/packages/tasks/src/zetachainWithdrawAndCall.ts
@@ -21,13 +21,13 @@ const zetachainWithdrawAndCallArgsSchema = z.object({
   gatewayZetaChain: evmAddressSchema.optional(),
   onRevertGasLimit: bigNumberStringSchema,
   receiver: z.string(),
-  revertAddress: z.string(),
-  revertMessage: z.string(),
+  revertAddress: evmAddressSchema,
+  revertMessage: evmAddressSchema,
   txOptionsGasLimit: bigNumberStringSchema,
   txOptionsGasPrice: bigNumberStringSchema,
   types: validJsonStringSchema,
   values: z.array(z.string()).min(1, "At least one value is required"),
-  zrc20: z.string(),
+  zrc20: evmAddressSchema,
 });
 
 type ZetachainWithdrawAndCallArgs = z.infer<

--- a/packages/tasks/src/zetachainWithdrawAndCall.ts
+++ b/packages/tasks/src/zetachainWithdrawAndCall.ts
@@ -60,11 +60,11 @@ export const zetachainWithdrawAndCall = async (
       gatewayZetaChain: parsedArgs.gatewayZetaChain,
       receiver: parsedArgs.receiver,
       revertOptions: {
+        abortAddress: parsedArgs.abortAddress,
         callOnRevert: parsedArgs.callOnRevert || false,
         onRevertGasLimit: parsedArgs.onRevertGasLimit,
         revertAddress: parsedArgs.revertAddress,
         revertMessage: parsedArgs.revertMessage,
-        abortAddress: parsedArgs.abortAddress,
       },
       txOptions: {
         gasLimit: parsedArgs.txOptionsGasLimit,


### PR DESCRIPTION
* feat: accept `abortAddress` as an arg in all Gateway functions
* refactor: pass `args.txOptions` directly in EVM Gateway functions without an unnecessary intermediary `const txOptions` variable
* refactor: spread operator inside `revertOptions` to avoid repetitive code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an optional "abort address" parameter across several transaction tasks, enabling users to specify an address to potentially abort a transaction (defaulting to a zero address).

- **Refactor**
  - Streamlined the processing of transaction and revert options by reducing redundancy and consolidating configuration settings for improved clarity and simplicity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->