### PR TITLE
feat: accounts commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "copy-types": "npx cpx './typechain-types/**/*' ./dist/typechain-types",
     "test": "jest",
     "test:watch": "jest --watch",
-    "toolkit": "yarn build && node dist/packages/commands/src/program.js",
-    "toolkit:dev": "npx ts-node packages/commands/src/program.ts"
+    "zetachain:build": "yarn build && node dist/packages/commands/src/program.js",
+    "zetachain": "npx ts-node packages/commands/src/program.ts"
   },
   "keywords": [],
   "author": "ZetaChain",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "copy-types": "npx cpx './typechain-types/**/*' ./dist/typechain-types",
     "test": "jest",
     "test:watch": "jest --watch",
-    "toolkit": "yarn build && node dist/packages/commands/src/program.js"
+    "toolkit": "yarn build && node dist/packages/commands/src/program.js",
+    "toolkit:dev": "npx ts-node packages/commands/src/program.ts"
   },
   "keywords": [],
   "author": "ZetaChain",

--- a/packages/commands/src/accounts/create.ts
+++ b/packages/commands/src/accounts/create.ts
@@ -5,6 +5,7 @@ import { ethers } from "ethers";
 import fs from "fs";
 import os from "os";
 import path from "path";
+
 import { AccountData } from "../../../../types/accounts.types";
 
 const createEVMAccount = (): AccountData => {

--- a/packages/commands/src/accounts/create.ts
+++ b/packages/commands/src/accounts/create.ts
@@ -5,10 +5,7 @@ import { ethers } from "ethers";
 import fs from "fs";
 import os from "os";
 import path from "path";
-
-interface AccountData {
-  [key: string]: string | undefined;
-}
+import { AccountData } from "../../../../types/accounts.types";
 
 const createEVMAccount = (): AccountData => {
   const wallet = ethers.Wallet.createRandom();

--- a/packages/commands/src/accounts/create.ts
+++ b/packages/commands/src/accounts/create.ts
@@ -70,7 +70,9 @@ const createAccountForType = async (
 };
 
 const main = async (options: CreateAccountOptions) => {
-  const { type, name } = validateTaskArgs(options, createAccountOptionsSchema);
+  const { type, name } = validateTaskArgs(options, createAccountOptionsSchema, {
+    exitOnError: true,
+  });
 
   if (type) {
     await createAccountForType(type, name);

--- a/packages/commands/src/accounts/create.ts
+++ b/packages/commands/src/accounts/create.ts
@@ -2,7 +2,6 @@ import confirm from "@inquirer/confirm";
 import { Keypair } from "@solana/web3.js";
 import { Command, Option } from "commander";
 import { ethers } from "ethers";
-import fs from "fs";
 import { z } from "zod";
 
 import {
@@ -10,6 +9,11 @@ import {
   accountNameSchema,
   AvailableAccountTypes,
 } from "../../../../types/accounts.types";
+import {
+  safeExists,
+  safeMkdir,
+  safeWriteFile,
+} from "../../../../utils/fsUtils";
 import { handleError } from "../../../../utils/handleError";
 import {
   getAccountKeyPath,
@@ -51,11 +55,11 @@ const createAccountForType = async (
 ): Promise<void> => {
   try {
     const baseDir = getAccountTypeDir(type);
-    fs.mkdirSync(baseDir, { recursive: true });
+    safeMkdir(baseDir);
 
     const keyPath = getAccountKeyPath(type, name);
 
-    if (fs.existsSync(keyPath)) {
+    if (safeExists(keyPath)) {
       const shouldOverwrite = await confirm({
         default: false,
         message: `File ${keyPath} already exists. Overwrite?`,
@@ -68,7 +72,7 @@ const createAccountForType = async (
 
     const keyData = type === "evm" ? createEVMAccount() : createSolanaAccount();
 
-    fs.writeFileSync(keyPath, JSON.stringify(keyData, null, 2));
+    safeWriteFile(keyPath, keyData);
     console.log(`${type.toUpperCase()} account created successfully!`);
     console.log(`Key saved to: ${keyPath}`);
     if (type === "evm") {

--- a/packages/commands/src/accounts/create.ts
+++ b/packages/commands/src/accounts/create.ts
@@ -5,8 +5,17 @@ import { ethers } from "ethers";
 import fs from "fs";
 import os from "os";
 import path from "path";
+import { z } from "zod";
 
 import { AccountData } from "../../../../types/accounts.types";
+import { validateTaskArgs } from "../../../../utils";
+
+const createAccountOptionsSchema = z.object({
+  name: z.string().min(1, "Account name is required"),
+  type: z.enum(["evm", "solana"]).optional(),
+});
+
+type CreateAccountOptions = z.infer<typeof createAccountOptionsSchema>;
 
 const createEVMAccount = (): AccountData => {
   const wallet = ethers.Wallet.createRandom();
@@ -56,13 +65,8 @@ const createAccountForType = async (
   }
 };
 
-const main = async (options: { name: string; type?: string }) => {
-  const { type, name } = options;
-
-  if (type && type !== "evm" && type !== "solana") {
-    console.error("Invalid account type. Must be either 'evm' or 'solana'");
-    return;
-  }
+const main = async (options: CreateAccountOptions) => {
+  const { type, name } = validateTaskArgs(options, createAccountOptionsSchema);
 
   if (type) {
     await createAccountForType(type, name);

--- a/packages/commands/src/accounts/create.ts
+++ b/packages/commands/src/accounts/create.ts
@@ -3,49 +3,31 @@ import { ethers } from "ethers";
 import fs from "fs";
 import path from "path";
 import os from "os";
+import confirm from "@inquirer/confirm";
 
 async function main(options: { type: string; name: string }) {
   const { type, name } = options;
-
-  // Create wallet
   const wallet = ethers.Wallet.createRandom();
 
-  // Prepare directory structure
   const baseDir = path.join(os.homedir(), ".zetachain", "keys", type);
   fs.mkdirSync(baseDir, { recursive: true });
 
-  // Save private key
   const keyPath = path.join(baseDir, `${name}.json`);
+  if (fs.existsSync(keyPath)) {
+    const shouldOverwrite = await confirm({
+      message: `File ${keyPath} already exists. Overwrite?`,
+      default: false,
+    });
+    if (!shouldOverwrite) {
+      console.log("Operation cancelled.");
+      return;
+    }
+  }
+
   const keyData = {
-    // Standard EVM key format
     address: wallet.address,
     privateKey: wallet.privateKey,
-    // For compatibility with MetaMask and other tools
     mnemonic: wallet.mnemonic?.phrase,
-    // For compatibility with Geth/Go Ethereum
-    crypto: {
-      cipher: "aes-128-ctr",
-      ciphertext: wallet.privateKey,
-      cipherparams: {
-        iv: ethers.hexlify(ethers.randomBytes(16)),
-      },
-      kdf: "scrypt",
-      kdfparams: {
-        dklen: 32,
-        n: 262144,
-        r: 8,
-        p: 1,
-        salt: ethers.hexlify(ethers.randomBytes(32)),
-      },
-      mac: ethers
-        .keccak256(
-          ethers.concat([
-            ethers.randomBytes(32),
-            ethers.getBytes(wallet.privateKey),
-          ])
-        )
-        .slice(2),
-    },
   };
 
   fs.writeFileSync(keyPath, JSON.stringify(keyData, null, 2));

--- a/packages/commands/src/accounts/create.ts
+++ b/packages/commands/src/accounts/create.ts
@@ -1,10 +1,10 @@
+import confirm from "@inquirer/confirm";
+import { Keypair } from "@solana/web3.js";
 import { Command } from "commander";
 import { ethers } from "ethers";
-import { Keypair } from "@solana/web3.js";
 import fs from "fs";
-import path from "path";
 import os from "os";
-import confirm from "@inquirer/confirm";
+import path from "path";
 
 interface AccountData {
   [key: string]: string | undefined;
@@ -14,8 +14,8 @@ async function createEVMAccount(): Promise<AccountData> {
   const wallet = ethers.Wallet.createRandom();
   return {
     address: wallet.address,
-    privateKey: wallet.privateKey,
     mnemonic: wallet.mnemonic?.phrase,
+    privateKey: wallet.privateKey,
   };
 }
 
@@ -27,7 +27,7 @@ async function createSolanaAccount(): Promise<AccountData> {
   };
 }
 
-async function main(options: { type: string; name: string }) {
+async function main(options: { name: string; type: string }) {
   const { type, name } = options;
 
   if (type !== "evm" && type !== "solana") {
@@ -41,8 +41,8 @@ async function main(options: { type: string; name: string }) {
   const keyPath = path.join(baseDir, `${name}.json`);
   if (fs.existsSync(keyPath)) {
     const shouldOverwrite = await confirm({
-      message: `File ${keyPath} already exists. Overwrite?`,
       default: false,
+      message: `File ${keyPath} already exists. Overwrite?`,
     });
     if (!shouldOverwrite) {
       console.log("Operation cancelled.");

--- a/packages/commands/src/accounts/create.ts
+++ b/packages/commands/src/accounts/create.ts
@@ -10,24 +10,24 @@ interface AccountData {
   [key: string]: string | undefined;
 }
 
-async function createEVMAccount(): Promise<AccountData> {
+const createEVMAccount = (): AccountData => {
   const wallet = ethers.Wallet.createRandom();
   return {
     address: wallet.address,
     mnemonic: wallet.mnemonic?.phrase,
     privateKey: wallet.privateKey,
   };
-}
+};
 
-async function createSolanaAccount(): Promise<AccountData> {
+const createSolanaAccount = (): AccountData => {
   const keypair = Keypair.generate();
   return {
     publicKey: keypair.publicKey.toBase58(),
     secretKey: Buffer.from(keypair.secretKey).toString("hex"),
   };
-}
+};
 
-async function main(options: { name: string; type: string }) {
+const main = async (options: { name: string; type: string }) => {
   const { type, name } = options;
 
   if (type !== "evm" && type !== "solana") {
@@ -50,8 +50,7 @@ async function main(options: { name: string; type: string }) {
     }
   }
 
-  const keyData =
-    type === "evm" ? await createEVMAccount() : await createSolanaAccount();
+  const keyData = type === "evm" ? createEVMAccount() : createSolanaAccount();
 
   fs.writeFileSync(keyPath, JSON.stringify(keyData, null, 2));
   console.log(`Account created successfully!`);
@@ -61,7 +60,7 @@ async function main(options: { name: string; type: string }) {
   } else {
     console.log(`Public Key: ${keyData.publicKey}`);
   }
-}
+};
 
 export const createAccountsCommand = new Command("create")
   .description("Create a new account")

--- a/packages/commands/src/accounts/create.ts
+++ b/packages/commands/src/accounts/create.ts
@@ -12,7 +12,11 @@ import { validateTaskArgs } from "../../../../utils";
 
 const createAccountOptionsSchema = z.object({
   name: z.string().min(1, "Account name is required"),
-  type: z.enum(["evm", "solana"]).optional(),
+  type: z
+    .enum(["evm", "solana"], {
+      errorMap: () => ({ message: "Type must be either 'evm' or 'solana'" }),
+    })
+    .optional(),
 });
 
 type CreateAccountOptions = z.infer<typeof createAccountOptionsSchema>;

--- a/packages/commands/src/accounts/create.ts
+++ b/packages/commands/src/accounts/create.ts
@@ -1,0 +1,61 @@
+import { Command } from "commander";
+import { ethers } from "ethers";
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+async function main(options: { type: string; name: string }) {
+  const { type, name } = options;
+
+  // Create wallet
+  const wallet = ethers.Wallet.createRandom();
+
+  // Prepare directory structure
+  const baseDir = path.join(os.homedir(), ".zetachain", "keys", type);
+  fs.mkdirSync(baseDir, { recursive: true });
+
+  // Save private key
+  const keyPath = path.join(baseDir, `${name}.json`);
+  const keyData = {
+    // Standard EVM key format
+    address: wallet.address,
+    privateKey: wallet.privateKey,
+    // For compatibility with MetaMask and other tools
+    mnemonic: wallet.mnemonic?.phrase,
+    // For compatibility with Geth/Go Ethereum
+    crypto: {
+      cipher: "aes-128-ctr",
+      ciphertext: wallet.privateKey,
+      cipherparams: {
+        iv: ethers.hexlify(ethers.randomBytes(16)),
+      },
+      kdf: "scrypt",
+      kdfparams: {
+        dklen: 32,
+        n: 262144,
+        r: 8,
+        p: 1,
+        salt: ethers.hexlify(ethers.randomBytes(32)),
+      },
+      mac: ethers
+        .keccak256(
+          ethers.concat([
+            ethers.randomBytes(32),
+            ethers.getBytes(wallet.privateKey),
+          ])
+        )
+        .slice(2),
+    },
+  };
+
+  fs.writeFileSync(keyPath, JSON.stringify(keyData, null, 2));
+  console.log(`Account created successfully!`);
+  console.log(`Private key saved to: ${keyPath}`);
+  console.log(`Address: ${wallet.address}`);
+}
+
+export const createAccountsCommand = new Command("create")
+  .description("Create a new account")
+  .requiredOption("--type <type>", "Account type (e.g. evm)")
+  .requiredOption("--name <name>", "Account name")
+  .action(main);

--- a/packages/commands/src/accounts/delete.ts
+++ b/packages/commands/src/accounts/delete.ts
@@ -1,0 +1,41 @@
+import confirm from "@inquirer/confirm";
+import { Command } from "commander";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+const main = async (options: { name: string; type: string }) => {
+  const { type, name } = options;
+
+  if (type !== "evm" && type !== "solana") {
+    console.error("Invalid account type. Must be either 'evm' or 'solana'");
+    return;
+  }
+
+  const baseDir = path.join(os.homedir(), ".zetachain", "keys", type);
+  const keyPath = path.join(baseDir, `${name}.json`);
+
+  if (!fs.existsSync(keyPath)) {
+    console.error(`Account ${name} of type ${type} not found at ${keyPath}`);
+    return;
+  }
+
+  const shouldDelete = await confirm({
+    default: false,
+    message: `Are you sure you want to delete account ${name} of type ${type}? This action cannot be undone.`,
+  });
+
+  if (!shouldDelete) {
+    console.log("Operation cancelled.");
+    return;
+  }
+
+  fs.unlinkSync(keyPath);
+  console.log(`Account ${name} of type ${type} deleted successfully.`);
+};
+
+export const deleteAccountsCommand = new Command("delete")
+  .description("Delete an existing account")
+  .requiredOption("--type <type>", "Account type (evm or solana)")
+  .requiredOption("--name <name>", "Account name")
+  .action(main);

--- a/packages/commands/src/accounts/delete.ts
+++ b/packages/commands/src/accounts/delete.ts
@@ -1,16 +1,18 @@
 import confirm from "@inquirer/confirm";
 import { Command, Option } from "commander";
 import fs from "fs";
-import os from "os";
-import path from "path";
 import { z } from "zod";
 
-import { AvailableAccountTypes } from "../../../../types/accounts.types";
+import {
+  accountNameSchema,
+  AvailableAccountTypes,
+} from "../../../../types/accounts.types";
 import { handleError } from "../../../../utils/handleError";
+import { getAccountKeyPath } from "../../../../utils/keyPaths";
 import { validateAndParseSchema } from "../../../../utils/validateAndParseSchema";
 
 const deleteAccountOptionsSchema = z.object({
-  name: z.string().min(1, "Account name is required"),
+  name: accountNameSchema,
   type: z.enum(AvailableAccountTypes, {
     errorMap: () => ({ message: "Type must be either 'evm' or 'solana'" }),
   }),
@@ -21,8 +23,7 @@ type DeleteAccountOptions = z.infer<typeof deleteAccountOptionsSchema>;
 const main = async (options: DeleteAccountOptions) => {
   const { type, name } = options;
 
-  const baseDir = path.join(os.homedir(), ".zetachain", "keys", type);
-  const keyPath = path.join(baseDir, `${name}.json`);
+  const keyPath = getAccountKeyPath(type, name);
 
   if (!fs.existsSync(keyPath)) {
     console.error(`Account ${name} of type ${type} not found at ${keyPath}`);

--- a/packages/commands/src/accounts/delete.ts
+++ b/packages/commands/src/accounts/delete.ts
@@ -3,14 +3,21 @@ import { Command } from "commander";
 import fs from "fs";
 import os from "os";
 import path from "path";
+import { z } from "zod";
 
-const main = async (options: { name: string; type: string }) => {
-  const { type, name } = options;
+import { validateTaskArgs } from "../../../../utils";
 
-  if (type !== "evm" && type !== "solana") {
-    console.error("Invalid account type. Must be either 'evm' or 'solana'");
-    return;
-  }
+const deleteAccountOptionsSchema = z.object({
+  name: z.string().min(1, "Account name is required"),
+  type: z.enum(["evm", "solana"], {
+    errorMap: () => ({ message: "Type must be either 'evm' or 'solana'" }),
+  }),
+});
+
+type DeleteAccountOptions = z.infer<typeof deleteAccountOptionsSchema>;
+
+const main = async (options: DeleteAccountOptions) => {
+  const { type, name } = validateTaskArgs(options, deleteAccountOptionsSchema);
 
   const baseDir = path.join(os.homedir(), ".zetachain", "keys", type);
   const keyPath = path.join(baseDir, `${name}.json`);

--- a/packages/commands/src/accounts/delete.ts
+++ b/packages/commands/src/accounts/delete.ts
@@ -17,7 +17,9 @@ const deleteAccountOptionsSchema = z.object({
 type DeleteAccountOptions = z.infer<typeof deleteAccountOptionsSchema>;
 
 const main = async (options: DeleteAccountOptions) => {
-  const { type, name } = validateTaskArgs(options, deleteAccountOptionsSchema);
+  const { type, name } = validateTaskArgs(options, deleteAccountOptionsSchema, {
+    exitOnError: true,
+  });
 
   const baseDir = path.join(os.homedir(), ".zetachain", "keys", type);
   const keyPath = path.join(baseDir, `${name}.json`);

--- a/packages/commands/src/accounts/delete.ts
+++ b/packages/commands/src/accounts/delete.ts
@@ -1,12 +1,12 @@
 import confirm from "@inquirer/confirm";
 import { Command, Option } from "commander";
-import fs from "fs";
 import { z } from "zod";
 
 import {
   accountNameSchema,
   AvailableAccountTypes,
 } from "../../../../types/accounts.types";
+import { safeExists, safeUnlink } from "../../../../utils/fsUtils";
 import { handleError } from "../../../../utils/handleError";
 import { getAccountKeyPath } from "../../../../utils/keyPaths";
 import { validateAndParseSchema } from "../../../../utils/validateAndParseSchema";
@@ -25,7 +25,7 @@ const main = async (options: DeleteAccountOptions) => {
 
   const keyPath = getAccountKeyPath(type, name);
 
-  if (!fs.existsSync(keyPath)) {
+  if (!safeExists(keyPath)) {
     console.error(`Account ${name} of type ${type} not found at ${keyPath}`);
     return;
   }
@@ -41,7 +41,7 @@ const main = async (options: DeleteAccountOptions) => {
   }
 
   try {
-    fs.unlinkSync(keyPath);
+    safeUnlink(keyPath);
     console.log(`Account ${name} of type ${type} deleted successfully.`);
   } catch (error: unknown) {
     handleError({

--- a/packages/commands/src/accounts/delete.ts
+++ b/packages/commands/src/accounts/delete.ts
@@ -6,6 +6,7 @@ import path from "path";
 import { z } from "zod";
 
 import { AvailableAccountTypes } from "../../../../types/accounts.types";
+import { handleError } from "../../../../utils/handleError";
 import { validateAndParseSchema } from "../../../../utils/validateAndParseSchema";
 
 const deleteAccountOptionsSchema = z.object({
@@ -38,8 +39,16 @@ const main = async (options: DeleteAccountOptions) => {
     return;
   }
 
-  fs.unlinkSync(keyPath);
-  console.log(`Account ${name} of type ${type} deleted successfully.`);
+  try {
+    fs.unlinkSync(keyPath);
+    console.log(`Account ${name} of type ${type} deleted successfully.`);
+  } catch (error: unknown) {
+    handleError({
+      context: "Failed to delete account",
+      error,
+      shouldThrow: true,
+    });
+  }
 };
 
 export const deleteAccountsCommand = new Command("delete")

--- a/packages/commands/src/accounts/index.ts
+++ b/packages/commands/src/accounts/index.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 
 import { createAccountsCommand } from "./create";
+import { deleteAccountsCommand } from "./delete";
 import { listAccountsCommand } from "./list";
 import { showAccountsCommand } from "./show";
 
@@ -8,4 +9,5 @@ export const accountsCommand = new Command("accounts")
   .description("Account management commands")
   .addCommand(createAccountsCommand)
   .addCommand(showAccountsCommand)
-  .addCommand(listAccountsCommand);
+  .addCommand(listAccountsCommand)
+  .addCommand(deleteAccountsCommand);

--- a/packages/commands/src/accounts/index.ts
+++ b/packages/commands/src/accounts/index.ts
@@ -1,6 +1,8 @@
 import { Command } from "commander";
 import { createAccountsCommand } from "./create";
+import { showAccountsCommand } from "./show";
 
 export const accountsCommand = new Command("accounts")
   .description("Account management commands")
-  .addCommand(createAccountsCommand);
+  .addCommand(createAccountsCommand)
+  .addCommand(showAccountsCommand);

--- a/packages/commands/src/accounts/index.ts
+++ b/packages/commands/src/accounts/index.ts
@@ -1,8 +1,11 @@
 import { Command } from "commander";
+
 import { createAccountsCommand } from "./create";
+import { listAccountsCommand } from "./list";
 import { showAccountsCommand } from "./show";
 
 export const accountsCommand = new Command("accounts")
   .description("Account management commands")
   .addCommand(createAccountsCommand)
-  .addCommand(showAccountsCommand);
+  .addCommand(showAccountsCommand)
+  .addCommand(listAccountsCommand);

--- a/packages/commands/src/accounts/index.ts
+++ b/packages/commands/src/accounts/index.ts
@@ -1,0 +1,6 @@
+import { Command } from "commander";
+import { createAccountsCommand } from "./create";
+
+export const accountsCommand = new Command("accounts")
+  .description("Account management commands")
+  .addCommand(createAccountsCommand);

--- a/packages/commands/src/accounts/list.ts
+++ b/packages/commands/src/accounts/list.ts
@@ -2,20 +2,11 @@ import { Command } from "commander";
 import fs from "fs";
 import os from "os";
 import path from "path";
-
-interface AccountInfo {
-  Address: string;
-  Name: string;
-  Type: string;
-}
-
-interface EVMAccountData {
-  address: string;
-}
-
-interface SolanaAccountData {
-  publicKey: string;
-}
+import {
+  AccountInfo,
+  EVMAccountData,
+  SolanaAccountData,
+} from "../../../../types/accounts.types";
 
 const main = (): void => {
   const baseDir = path.join(os.homedir(), ".zetachain", "keys");

--- a/packages/commands/src/accounts/list.ts
+++ b/packages/commands/src/accounts/list.ts
@@ -47,7 +47,9 @@ const listChainAccounts = (
 type ListAccountsOptions = z.infer<typeof listAccountsOptionsSchema>;
 
 const main = (options: ListAccountsOptions): void => {
-  const { json } = validateTaskArgs(options, listAccountsOptionsSchema);
+  const { json } = validateTaskArgs(options, listAccountsOptionsSchema, {
+    exitOnError: true,
+  });
   const baseDir = path.join(os.homedir(), ".zetachain", "keys");
   const accounts: AccountInfo[] = [];
 

--- a/packages/commands/src/accounts/list.ts
+++ b/packages/commands/src/accounts/list.ts
@@ -1,5 +1,4 @@
 import { Command } from "commander";
-import fs from "fs";
 import path from "path";
 import { z } from "zod";
 
@@ -10,6 +9,11 @@ import {
   EVMAccountData,
   SolanaAccountData,
 } from "../../../../types/accounts.types";
+import {
+  safeExists,
+  safeReadDir,
+  safeReadFile,
+} from "../../../../utils/fsUtils";
 import { getAccountTypeDir } from "../../../../utils/keyPaths";
 import { parseJson } from "../../../../utils/parseJson";
 import { validateAndParseSchema } from "../../../../utils/validateAndParseSchema";
@@ -23,18 +27,13 @@ const listChainAccounts = (
   accounts: AccountInfo[]
 ): void => {
   const chainDir = getAccountTypeDir(chainType);
-  if (!fs.existsSync(chainDir)) return;
+  if (!safeExists(chainDir)) return;
 
-  const files = fs
-    .readdirSync(chainDir)
-    .filter((file) => file.endsWith(".json"));
+  const files = safeReadDir(chainDir).filter((file) => file.endsWith(".json"));
 
   for (const file of files) {
     const keyPath = path.join(chainDir, file);
-    const keyData = parseJson(
-      fs.readFileSync(keyPath, "utf-8"),
-      accountDataSchema
-    );
+    const keyData = parseJson(safeReadFile(keyPath), accountDataSchema);
 
     accounts.push({
       address:

--- a/packages/commands/src/accounts/list.ts
+++ b/packages/commands/src/accounts/list.ts
@@ -9,7 +9,8 @@ import {
   SolanaAccountData,
 } from "../../../../types/accounts.types";
 
-const main = (): void => {
+const main = (options: { json: boolean }): void => {
+  const { json } = options;
   const baseDir = path.join(os.homedir(), ".zetachain", "keys");
   const accounts: AccountInfo[] = [];
 
@@ -56,10 +57,15 @@ const main = (): void => {
     return;
   }
 
-  console.log("\nAvailable Accounts:");
-  console.table(accounts);
+  if (json) {
+    console.log(JSON.stringify(accounts, null, 2));
+  } else {
+    console.log("\nAvailable Accounts:");
+    console.table(accounts);
+  }
 };
 
 export const listAccountsCommand = new Command("list")
   .description("List all available accounts")
+  .option("--json", "Output in JSON format")
   .action(main);

--- a/packages/commands/src/accounts/list.ts
+++ b/packages/commands/src/accounts/list.ts
@@ -26,9 +26,9 @@ const main = (options: { json: boolean }): void => {
         fs.readFileSync(keyPath, "utf-8")
       ) as EVMAccountData;
       accounts.push({
-        Address: keyData.address,
-        Name: file.replace(".json", ""),
-        Type: "EVM",
+        address: keyData.address,
+        name: file.replace(".json", ""),
+        type: "evm",
       });
     }
   }
@@ -45,9 +45,9 @@ const main = (options: { json: boolean }): void => {
         fs.readFileSync(keyPath, "utf-8")
       ) as SolanaAccountData;
       accounts.push({
-        Address: keyData.publicKey,
-        Name: file.replace(".json", ""),
-        Type: "Solana",
+        address: keyData.publicKey,
+        name: file.replace(".json", ""),
+        type: "solana",
       });
     }
   }

--- a/packages/commands/src/accounts/list.ts
+++ b/packages/commands/src/accounts/list.ts
@@ -1,0 +1,61 @@
+import { Command } from "commander";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+interface AccountInfo {
+  Address: string;
+  Name: string;
+  Type: string;
+}
+
+async function main() {
+  const baseDir = path.join(os.homedir(), ".zetachain", "keys");
+  const accounts: AccountInfo[] = [];
+
+  // List EVM accounts
+  const evmDir = path.join(baseDir, "evm");
+  if (fs.existsSync(evmDir)) {
+    const evmFiles = fs
+      .readdirSync(evmDir)
+      .filter((file) => file.endsWith(".json"));
+    for (const file of evmFiles) {
+      const keyPath = path.join(evmDir, file);
+      const keyData = JSON.parse(fs.readFileSync(keyPath, "utf-8"));
+      accounts.push({
+        Address: keyData.address,
+        Name: file.replace(".json", ""),
+        Type: "EVM",
+      });
+    }
+  }
+
+  // List Solana accounts
+  const solanaDir = path.join(baseDir, "solana");
+  if (fs.existsSync(solanaDir)) {
+    const solanaFiles = fs
+      .readdirSync(solanaDir)
+      .filter((file) => file.endsWith(".json"));
+    for (const file of solanaFiles) {
+      const keyPath = path.join(solanaDir, file);
+      const keyData = JSON.parse(fs.readFileSync(keyPath, "utf-8"));
+      accounts.push({
+        Address: keyData.publicKey,
+        Name: file.replace(".json", ""),
+        Type: "Solana",
+      });
+    }
+  }
+
+  if (accounts.length === 0) {
+    console.log("No accounts found.");
+    return;
+  }
+
+  console.log("\nAvailable Accounts:");
+  console.table(accounts);
+}
+
+export const listAccountsCommand = new Command("list")
+  .description("List all available accounts")
+  .action(main);

--- a/packages/commands/src/accounts/list.ts
+++ b/packages/commands/src/accounts/list.ts
@@ -1,6 +1,5 @@
 import { Command } from "commander";
 import fs from "fs";
-import os from "os";
 import path from "path";
 import { z } from "zod";
 
@@ -11,6 +10,7 @@ import {
   EVMAccountData,
   SolanaAccountData,
 } from "../../../../types/accounts.types";
+import { getAccountTypeDir } from "../../../../utils/keyPaths";
 import { parseJson } from "../../../../utils/parseJson";
 import { validateAndParseSchema } from "../../../../utils/validateAndParseSchema";
 
@@ -19,11 +19,10 @@ const listAccountsOptionsSchema = z.object({
 });
 
 const listChainAccounts = (
-  baseDir: string,
   chainType: (typeof AvailableAccountTypes)[number],
   accounts: AccountInfo[]
 ): void => {
-  const chainDir = path.join(baseDir, chainType);
+  const chainDir = getAccountTypeDir(chainType);
   if (!fs.existsSync(chainDir)) return;
 
   const files = fs
@@ -52,11 +51,10 @@ type ListAccountsOptions = z.infer<typeof listAccountsOptionsSchema>;
 
 const main = (options: ListAccountsOptions): void => {
   const { json } = options;
-  const baseDir = path.join(os.homedir(), ".zetachain", "keys");
   const accounts: AccountInfo[] = [];
 
-  listChainAccounts(baseDir, "evm", accounts);
-  listChainAccounts(baseDir, "solana", accounts);
+  listChainAccounts("evm", accounts);
+  listChainAccounts("solana", accounts);
 
   if (accounts.length === 0) {
     console.log("No accounts found.");

--- a/packages/commands/src/accounts/list.ts
+++ b/packages/commands/src/accounts/list.ts
@@ -5,11 +5,13 @@ import path from "path";
 import { z } from "zod";
 
 import {
+  accountDataSchema,
   AccountInfo,
   AvailableAccountTypes,
   EVMAccountData,
   SolanaAccountData,
 } from "../../../../types/accounts.types";
+import { parseJson } from "../../../../utils/parseJson";
 import { validateAndParseSchema } from "../../../../utils/validateAndParseSchema";
 
 const listAccountsOptionsSchema = z.object({
@@ -30,9 +32,10 @@ const listChainAccounts = (
 
   for (const file of files) {
     const keyPath = path.join(chainDir, file);
-    const keyData = JSON.parse(fs.readFileSync(keyPath, "utf-8")) as
-      | EVMAccountData
-      | SolanaAccountData;
+    const keyData = parseJson(
+      fs.readFileSync(keyPath, "utf-8"),
+      accountDataSchema
+    );
 
     accounts.push({
       address:

--- a/packages/commands/src/accounts/list.ts
+++ b/packages/commands/src/accounts/list.ts
@@ -9,7 +9,15 @@ interface AccountInfo {
   Type: string;
 }
 
-async function main() {
+interface EVMAccountData {
+  address: string;
+}
+
+interface SolanaAccountData {
+  publicKey: string;
+}
+
+const main = (): void => {
   const baseDir = path.join(os.homedir(), ".zetachain", "keys");
   const accounts: AccountInfo[] = [];
 
@@ -21,7 +29,9 @@ async function main() {
       .filter((file) => file.endsWith(".json"));
     for (const file of evmFiles) {
       const keyPath = path.join(evmDir, file);
-      const keyData = JSON.parse(fs.readFileSync(keyPath, "utf-8"));
+      const keyData = JSON.parse(
+        fs.readFileSync(keyPath, "utf-8")
+      ) as EVMAccountData;
       accounts.push({
         Address: keyData.address,
         Name: file.replace(".json", ""),
@@ -38,7 +48,9 @@ async function main() {
       .filter((file) => file.endsWith(".json"));
     for (const file of solanaFiles) {
       const keyPath = path.join(solanaDir, file);
-      const keyData = JSON.parse(fs.readFileSync(keyPath, "utf-8"));
+      const keyData = JSON.parse(
+        fs.readFileSync(keyPath, "utf-8")
+      ) as SolanaAccountData;
       accounts.push({
         Address: keyData.publicKey,
         Name: file.replace(".json", ""),
@@ -54,7 +66,7 @@ async function main() {
 
   console.log("\nAvailable Accounts:");
   console.table(accounts);
-}
+};
 
 export const listAccountsCommand = new Command("list")
   .description("List all available accounts")

--- a/packages/commands/src/accounts/list.ts
+++ b/packages/commands/src/accounts/list.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 
 import {
   AccountInfo,
+  AvailableAccountTypes,
   EVMAccountData,
   SolanaAccountData,
 } from "../../../../types/accounts.types";
@@ -17,7 +18,7 @@ const listAccountsOptionsSchema = z.object({
 
 const listChainAccounts = (
   baseDir: string,
-  chainType: "evm" | "solana",
+  chainType: (typeof AvailableAccountTypes)[number],
   accounts: AccountInfo[]
 ): void => {
   const chainDir = path.join(baseDir, chainType);
@@ -47,9 +48,7 @@ const listChainAccounts = (
 type ListAccountsOptions = z.infer<typeof listAccountsOptionsSchema>;
 
 const main = (options: ListAccountsOptions): void => {
-  const { json } = validateAndParseSchema(options, listAccountsOptionsSchema, {
-    exitOnError: true,
-  });
+  const { json } = options;
   const baseDir = path.join(os.homedir(), ".zetachain", "keys");
   const accounts: AccountInfo[] = [];
 
@@ -72,4 +71,9 @@ const main = (options: ListAccountsOptions): void => {
 export const listAccountsCommand = new Command("list")
   .description("List all available accounts")
   .option("--json", "Output in JSON format")
-  .action(main);
+  .action((opts) => {
+    const validated = validateAndParseSchema(opts, listAccountsOptionsSchema, {
+      exitOnError: true,
+    });
+    main(validated);
+  });

--- a/packages/commands/src/accounts/list.ts
+++ b/packages/commands/src/accounts/list.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import fs from "fs";
 import os from "os";
 import path from "path";
+
 import {
   AccountInfo,
   EVMAccountData,

--- a/packages/commands/src/accounts/list.ts
+++ b/packages/commands/src/accounts/list.ts
@@ -9,48 +9,42 @@ import {
   SolanaAccountData,
 } from "../../../../types/accounts.types";
 
+const listChainAccounts = (
+  baseDir: string,
+  chainType: "evm" | "solana",
+  accounts: AccountInfo[]
+): void => {
+  const chainDir = path.join(baseDir, chainType);
+  if (!fs.existsSync(chainDir)) return;
+
+  const files = fs
+    .readdirSync(chainDir)
+    .filter((file) => file.endsWith(".json"));
+
+  for (const file of files) {
+    const keyPath = path.join(chainDir, file);
+    const keyData = JSON.parse(fs.readFileSync(keyPath, "utf-8")) as
+      | EVMAccountData
+      | SolanaAccountData;
+
+    accounts.push({
+      address:
+        chainType === "evm"
+          ? (keyData as EVMAccountData).address
+          : (keyData as SolanaAccountData).publicKey,
+      name: file.replace(".json", ""),
+      type: chainType,
+    });
+  }
+};
+
 const main = (options: { json: boolean }): void => {
   const { json } = options;
   const baseDir = path.join(os.homedir(), ".zetachain", "keys");
   const accounts: AccountInfo[] = [];
 
-  // List EVM accounts
-  const evmDir = path.join(baseDir, "evm");
-  if (fs.existsSync(evmDir)) {
-    const evmFiles = fs
-      .readdirSync(evmDir)
-      .filter((file) => file.endsWith(".json"));
-    for (const file of evmFiles) {
-      const keyPath = path.join(evmDir, file);
-      const keyData = JSON.parse(
-        fs.readFileSync(keyPath, "utf-8")
-      ) as EVMAccountData;
-      accounts.push({
-        address: keyData.address,
-        name: file.replace(".json", ""),
-        type: "evm",
-      });
-    }
-  }
-
-  // List Solana accounts
-  const solanaDir = path.join(baseDir, "solana");
-  if (fs.existsSync(solanaDir)) {
-    const solanaFiles = fs
-      .readdirSync(solanaDir)
-      .filter((file) => file.endsWith(".json"));
-    for (const file of solanaFiles) {
-      const keyPath = path.join(solanaDir, file);
-      const keyData = JSON.parse(
-        fs.readFileSync(keyPath, "utf-8")
-      ) as SolanaAccountData;
-      accounts.push({
-        address: keyData.publicKey,
-        name: file.replace(".json", ""),
-        type: "solana",
-      });
-    }
-  }
+  listChainAccounts(baseDir, "evm", accounts);
+  listChainAccounts(baseDir, "solana", accounts);
 
   if (accounts.length === 0) {
     console.log("No accounts found.");

--- a/packages/commands/src/accounts/list.ts
+++ b/packages/commands/src/accounts/list.ts
@@ -2,12 +2,18 @@ import { Command } from "commander";
 import fs from "fs";
 import os from "os";
 import path from "path";
+import { z } from "zod";
 
 import {
   AccountInfo,
   EVMAccountData,
   SolanaAccountData,
 } from "../../../../types/accounts.types";
+import { validateTaskArgs } from "../../../../utils";
+
+const listAccountsOptionsSchema = z.object({
+  json: z.boolean().default(false),
+});
 
 const listChainAccounts = (
   baseDir: string,
@@ -38,8 +44,10 @@ const listChainAccounts = (
   }
 };
 
-const main = (options: { json: boolean }): void => {
-  const { json } = options;
+type ListAccountsOptions = z.infer<typeof listAccountsOptionsSchema>;
+
+const main = (options: ListAccountsOptions): void => {
+  const { json } = validateTaskArgs(options, listAccountsOptionsSchema);
   const baseDir = path.join(os.homedir(), ".zetachain", "keys");
   const accounts: AccountInfo[] = [];
 

--- a/packages/commands/src/accounts/show.ts
+++ b/packages/commands/src/accounts/show.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import fs from "fs";
 import os from "os";
 import path from "path";
+
 import {
   AccountDetails,
   EVMAccountData,

--- a/packages/commands/src/accounts/show.ts
+++ b/packages/commands/src/accounts/show.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import fs from "fs";
-import path from "path";
 import os from "os";
+import path from "path";
 
 interface AccountDetails {
   [key: string]: string;
@@ -9,12 +9,12 @@ interface AccountDetails {
 
 function getEVMAccountDetails(keyData: any, keyPath: string): AccountDetails {
   return {
-    Type: "EVM",
-    Name: keyData.name,
     Address: keyData.address,
-    "Private Key": keyData.privateKey,
-    Mnemonic: keyData.mnemonic || "N/A",
     "File Location": keyPath,
+    Mnemonic: keyData.mnemonic || "N/A",
+    Name: keyData.name,
+    "Private Key": keyData.privateKey,
+    Type: "EVM",
   };
 }
 
@@ -23,15 +23,15 @@ function getSolanaAccountDetails(
   keyPath: string
 ): AccountDetails {
   return {
-    Type: "Solana",
+    "File Location": keyPath,
     Name: keyData.name,
     "Public Key": keyData.publicKey,
     "Secret Key": keyData.secretKey,
-    "File Location": keyPath,
+    Type: "Solana",
   };
 }
 
-async function main(options: { type: string; name: string }) {
+async function main(options: { name: string; type: string }) {
   const { type, name } = options;
 
   if (type !== "evm" && type !== "solana") {

--- a/packages/commands/src/accounts/show.ts
+++ b/packages/commands/src/accounts/show.ts
@@ -1,22 +1,22 @@
 import { Command, Option } from "commander";
 import fs from "fs";
-import os from "os";
-import path from "path";
 import { z } from "zod";
 
 import {
   accountDataSchema,
   AccountDetails,
+  accountNameSchema,
   AvailableAccountTypes,
   EVMAccountData,
   SolanaAccountData,
 } from "../../../../types/accounts.types";
+import { getAccountKeyPath } from "../../../../utils/keyPaths";
 import { parseJson } from "../../../../utils/parseJson";
 import { validateAndParseSchema } from "../../../../utils/validateAndParseSchema";
 
 const showAccountOptionsSchema = z.object({
   json: z.boolean().default(false),
-  name: z.string().min(1, "Account name is required"),
+  name: accountNameSchema,
   type: z.enum(AvailableAccountTypes, {
     errorMap: () => ({ message: "Type must be either 'evm' or 'solana'" }),
   }),
@@ -54,8 +54,7 @@ const getSolanaAccountDetails = (
 const main = (options: ShowAccountOptions): void => {
   const { type, name, json } = options;
 
-  const baseDir = path.join(os.homedir(), ".zetachain", "keys", type);
-  const keyPath = path.join(baseDir, `${name}.json`);
+  const keyPath = getAccountKeyPath(type, name);
 
   if (!fs.existsSync(keyPath)) {
     console.error(`Account ${name} of type ${type} not found at ${keyPath}`);

--- a/packages/commands/src/accounts/show.ts
+++ b/packages/commands/src/accounts/show.ts
@@ -36,8 +36,8 @@ const getSolanaAccountDetails = (
   };
 };
 
-const main = (options: { name: string; type: string }): void => {
-  const { type, name } = options;
+const main = (options: { json: boolean; name: string; type: string }): void => {
+  const { type, name, json } = options;
 
   if (type !== "evm" && type !== "solana") {
     console.error("Invalid account type. Must be either 'evm' or 'solana'");
@@ -62,12 +62,17 @@ const main = (options: { name: string; type: string }): void => {
       ? getEVMAccountDetails(keyData as EVMAccountData, keyPath)
       : getSolanaAccountDetails(keyData as SolanaAccountData, keyPath);
 
-  console.log("\nAccount Details:");
-  console.table(accountDetails);
+  if (json) {
+    console.log(JSON.stringify(accountDetails, null, 2));
+  } else {
+    console.log("\nAccount Details:");
+    console.table(accountDetails);
+  }
 };
 
 export const showAccountsCommand = new Command("show")
   .description("Show details of an existing account")
   .requiredOption("--type <type>", "Account type (evm or solana)")
   .requiredOption("--name <name>", "Account name")
+  .option("--json", "Output in JSON format")
   .action(main);

--- a/packages/commands/src/accounts/show.ts
+++ b/packages/commands/src/accounts/show.ts
@@ -5,11 +5,13 @@ import path from "path";
 import { z } from "zod";
 
 import {
+  accountDataSchema,
   AccountDetails,
   AvailableAccountTypes,
   EVMAccountData,
   SolanaAccountData,
 } from "../../../../types/accounts.types";
+import { parseJson } from "../../../../utils/parseJson";
 import { validateAndParseSchema } from "../../../../utils/validateAndParseSchema";
 
 const showAccountOptionsSchema = z.object({
@@ -60,9 +62,10 @@ const main = (options: ShowAccountOptions): void => {
     process.exit(1);
   }
 
-  const keyData = JSON.parse(fs.readFileSync(keyPath, "utf-8")) as
-    | EVMAccountData
-    | SolanaAccountData;
+  const keyData = parseJson(
+    fs.readFileSync(keyPath, "utf-8"),
+    accountDataSchema
+  );
   keyData.name = name; // Add name to keyData for display
 
   const accountDetails =

--- a/packages/commands/src/accounts/show.ts
+++ b/packages/commands/src/accounts/show.ts
@@ -1,0 +1,35 @@
+import { Command } from "commander";
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+async function main(options: { type: string; name: string }) {
+  const { type, name } = options;
+  const baseDir = path.join(os.homedir(), ".zetachain", "keys", type);
+  const keyPath = path.join(baseDir, `${name}.json`);
+
+  if (!fs.existsSync(keyPath)) {
+    console.error(`Account ${name} of type ${type} not found at ${keyPath}`);
+    process.exit(1);
+  }
+
+  const keyData = JSON.parse(fs.readFileSync(keyPath, "utf-8"));
+
+  const accountDetails = {
+    Type: type,
+    Name: name,
+    Address: keyData.address,
+    "Private Key": keyData.privateKey,
+    Mnemonic: keyData.mnemonic || "N/A",
+    "File Location": keyPath,
+  };
+
+  console.log("\nAccount Details:");
+  console.table(accountDetails);
+}
+
+export const showAccountsCommand = new Command("show")
+  .description("Show details of an existing account")
+  .requiredOption("--type <type>", "Account type (e.g. evm)")
+  .requiredOption("--name <name>", "Account name")
+  .action(main);

--- a/packages/commands/src/accounts/show.ts
+++ b/packages/commands/src/accounts/show.ts
@@ -1,5 +1,4 @@
 import { Command, Option } from "commander";
-import fs from "fs";
 import { z } from "zod";
 
 import {
@@ -10,6 +9,7 @@ import {
   EVMAccountData,
   SolanaAccountData,
 } from "../../../../types/accounts.types";
+import { safeExists, safeReadFile } from "../../../../utils/fsUtils";
 import { getAccountKeyPath } from "../../../../utils/keyPaths";
 import { parseJson } from "../../../../utils/parseJson";
 import { validateAndParseSchema } from "../../../../utils/validateAndParseSchema";
@@ -56,15 +56,12 @@ const main = (options: ShowAccountOptions): void => {
 
   const keyPath = getAccountKeyPath(type, name);
 
-  if (!fs.existsSync(keyPath)) {
+  if (!safeExists(keyPath)) {
     console.error(`Account ${name} of type ${type} not found at ${keyPath}`);
     process.exit(1);
   }
 
-  const keyData = parseJson(
-    fs.readFileSync(keyPath, "utf-8"),
-    accountDataSchema
-  );
+  const keyData = parseJson(safeReadFile(keyPath), accountDataSchema);
   keyData.name = name; // Add name to keyData for display
 
   const accountDetails =

--- a/packages/commands/src/accounts/show.ts
+++ b/packages/commands/src/accounts/show.ts
@@ -3,8 +3,42 @@ import fs from "fs";
 import path from "path";
 import os from "os";
 
+interface AccountDetails {
+  [key: string]: string;
+}
+
+function getEVMAccountDetails(keyData: any, keyPath: string): AccountDetails {
+  return {
+    Type: "EVM",
+    Name: keyData.name,
+    Address: keyData.address,
+    "Private Key": keyData.privateKey,
+    Mnemonic: keyData.mnemonic || "N/A",
+    "File Location": keyPath,
+  };
+}
+
+function getSolanaAccountDetails(
+  keyData: any,
+  keyPath: string
+): AccountDetails {
+  return {
+    Type: "Solana",
+    Name: keyData.name,
+    "Public Key": keyData.publicKey,
+    "Secret Key": keyData.secretKey,
+    "File Location": keyPath,
+  };
+}
+
 async function main(options: { type: string; name: string }) {
   const { type, name } = options;
+
+  if (type !== "evm" && type !== "solana") {
+    console.error("Invalid account type. Must be either 'evm' or 'solana'");
+    process.exit(1);
+  }
+
   const baseDir = path.join(os.homedir(), ".zetachain", "keys", type);
   const keyPath = path.join(baseDir, `${name}.json`);
 
@@ -14,15 +48,12 @@ async function main(options: { type: string; name: string }) {
   }
 
   const keyData = JSON.parse(fs.readFileSync(keyPath, "utf-8"));
+  keyData.name = name; // Add name to keyData for display
 
-  const accountDetails = {
-    Type: type,
-    Name: name,
-    Address: keyData.address,
-    "Private Key": keyData.privateKey,
-    Mnemonic: keyData.mnemonic || "N/A",
-    "File Location": keyPath,
-  };
+  const accountDetails =
+    type === "evm"
+      ? getEVMAccountDetails(keyData, keyPath)
+      : getSolanaAccountDetails(keyData, keyPath);
 
   console.log("\nAccount Details:");
   console.table(accountDetails);
@@ -30,6 +61,6 @@ async function main(options: { type: string; name: string }) {
 
 export const showAccountsCommand = new Command("show")
   .description("Show details of an existing account")
-  .requiredOption("--type <type>", "Account type (e.g. evm)")
+  .requiredOption("--type <type>", "Account type (evm or solana)")
   .requiredOption("--name <name>", "Account name")
   .action(main);

--- a/packages/commands/src/accounts/show.ts
+++ b/packages/commands/src/accounts/show.ts
@@ -7,31 +7,47 @@ interface AccountDetails {
   [key: string]: string;
 }
 
-function getEVMAccountDetails(keyData: any, keyPath: string): AccountDetails {
+interface EVMAccountData {
+  address: string;
+  mnemonic?: string;
+  name?: string;
+  privateKey: string;
+}
+
+interface SolanaAccountData {
+  name?: string;
+  publicKey: string;
+  secretKey: string;
+}
+
+const getEVMAccountDetails = (
+  keyData: EVMAccountData,
+  keyPath: string
+): AccountDetails => {
   return {
     Address: keyData.address,
     "File Location": keyPath,
     Mnemonic: keyData.mnemonic || "N/A",
-    Name: keyData.name,
+    Name: keyData.name || "N/A",
     "Private Key": keyData.privateKey,
     Type: "EVM",
   };
-}
+};
 
-function getSolanaAccountDetails(
-  keyData: any,
+const getSolanaAccountDetails = (
+  keyData: SolanaAccountData,
   keyPath: string
-): AccountDetails {
+): AccountDetails => {
   return {
     "File Location": keyPath,
-    Name: keyData.name,
+    Name: keyData.name || "N/A",
     "Public Key": keyData.publicKey,
     "Secret Key": keyData.secretKey,
     Type: "Solana",
   };
-}
+};
 
-async function main(options: { name: string; type: string }) {
+const main = (options: { name: string; type: string }): void => {
   const { type, name } = options;
 
   if (type !== "evm" && type !== "solana") {
@@ -47,17 +63,19 @@ async function main(options: { name: string; type: string }) {
     process.exit(1);
   }
 
-  const keyData = JSON.parse(fs.readFileSync(keyPath, "utf-8"));
+  const keyData = JSON.parse(fs.readFileSync(keyPath, "utf-8")) as
+    | EVMAccountData
+    | SolanaAccountData;
   keyData.name = name; // Add name to keyData for display
 
   const accountDetails =
     type === "evm"
-      ? getEVMAccountDetails(keyData, keyPath)
-      : getSolanaAccountDetails(keyData, keyPath);
+      ? getEVMAccountDetails(keyData as EVMAccountData, keyPath)
+      : getSolanaAccountDetails(keyData as SolanaAccountData, keyPath);
 
   console.log("\nAccount Details:");
   console.table(accountDetails);
-}
+};
 
 export const showAccountsCommand = new Command("show")
   .description("Show details of an existing account")

--- a/packages/commands/src/accounts/show.ts
+++ b/packages/commands/src/accounts/show.ts
@@ -14,12 +14,12 @@ const getEVMAccountDetails = (
   keyPath: string
 ): AccountDetails => {
   return {
-    Address: keyData.address,
-    "File Location": keyPath,
-    Mnemonic: keyData.mnemonic || "N/A",
-    Name: keyData.name || "N/A",
-    "Private Key": keyData.privateKey,
-    Type: "EVM",
+    address: keyData.address,
+    fileLocation: keyPath,
+    mnemonic: keyData.mnemonic || "N/A",
+    name: keyData.name || "N/A",
+    privateKey: keyData.privateKey,
+    type: "evm",
   };
 };
 
@@ -28,11 +28,11 @@ const getSolanaAccountDetails = (
   keyPath: string
 ): AccountDetails => {
   return {
-    "File Location": keyPath,
-    Name: keyData.name || "N/A",
-    "Public Key": keyData.publicKey,
-    "Secret Key": keyData.secretKey,
-    Type: "Solana",
+    fileLocation: keyPath,
+    name: keyData.name || "N/A",
+    publicKey: keyData.publicKey,
+    secretKey: keyData.secretKey,
+    type: "solana",
   };
 };
 

--- a/packages/commands/src/accounts/show.ts
+++ b/packages/commands/src/accounts/show.ts
@@ -51,7 +51,8 @@ const getSolanaAccountDetails = (
 const main = (options: ShowAccountOptions): void => {
   const { type, name, json } = validateTaskArgs(
     options,
-    showAccountOptionsSchema
+    showAccountOptionsSchema,
+    { exitOnError: true }
   );
 
   const baseDir = path.join(os.homedir(), ".zetachain", "keys", type);

--- a/packages/commands/src/accounts/show.ts
+++ b/packages/commands/src/accounts/show.ts
@@ -58,7 +58,7 @@ const main = (options: ShowAccountOptions): void => {
 
   if (!safeExists(keyPath)) {
     console.error(`Account ${name} of type ${type} not found at ${keyPath}`);
-    process.exit(1);
+    return;
   }
 
   const keyData = parseJson(safeReadFile(keyPath), accountDataSchema);

--- a/packages/commands/src/accounts/show.ts
+++ b/packages/commands/src/accounts/show.ts
@@ -2,23 +2,11 @@ import { Command } from "commander";
 import fs from "fs";
 import os from "os";
 import path from "path";
-
-interface AccountDetails {
-  [key: string]: string;
-}
-
-interface EVMAccountData {
-  address: string;
-  mnemonic?: string;
-  name?: string;
-  privateKey: string;
-}
-
-interface SolanaAccountData {
-  name?: string;
-  publicKey: string;
-  secretKey: string;
-}
+import {
+  AccountDetails,
+  EVMAccountData,
+  SolanaAccountData,
+} from "../../../../types/accounts.types";
 
 const getEVMAccountDetails = (
   keyData: EVMAccountData,

--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -1,9 +1,11 @@
 import { Command } from "commander";
 
 import { solanaEncodeCommand } from "./solanaEncode";
+import { accountsCommand } from "./accounts";
 
 export const toolkitCommand = new Command("toolkit")
   .description("Local development environment")
   .helpCommand(false);
 
 toolkitCommand.addCommand(solanaEncodeCommand);
+toolkitCommand.addCommand(accountsCommand);

--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 
-import { solanaEncodeCommand } from "./solanaEncode";
 import { accountsCommand } from "./accounts";
+import { solanaEncodeCommand } from "./solanaEncode";
 
 export const toolkitCommand = new Command("toolkit")
   .description("Local development environment")

--- a/test/fsUtils.test.ts
+++ b/test/fsUtils.test.ts
@@ -1,0 +1,286 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+import fs from "fs";
+
+import {
+  safeExists,
+  safeMkdir,
+  safeReadDir,
+  safeReadFile,
+  safeReadJson,
+  safeUnlink,
+  safeWriteFile,
+} from "../utils/fsUtils";
+import { handleError } from "../utils/handleError";
+
+// Mock fs module
+jest.mock("fs");
+
+// Mock handleError utility
+jest.mock("../utils/handleError");
+
+describe("fsUtils", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("safeReadFile", () => {
+    it("should read file content successfully", () => {
+      const mockContent = "file content";
+      (fs.readFileSync as jest.Mock).mockReturnValue(mockContent);
+
+      const result = safeReadFile("test.txt");
+
+      expect(result).toBe(mockContent);
+      expect(fs.readFileSync).toHaveBeenCalledWith("test.txt", {
+        encoding: "utf-8",
+      });
+    });
+
+    it("should handle errors when reading file", () => {
+      const mockError = new Error("File not found");
+      (fs.readFileSync as jest.Mock).mockImplementation(() => {
+        throw mockError;
+      });
+
+      // This would throw, but we mock handleError
+      safeReadFile("nonexistent.txt");
+
+      expect(fs.readFileSync).toHaveBeenCalledWith("nonexistent.txt", {
+        encoding: "utf-8",
+      });
+      expect(handleError).toHaveBeenCalledWith({
+        context: "Failed to read file at nonexistent.txt",
+        error: mockError,
+        shouldThrow: true,
+      });
+    });
+  });
+
+  describe("safeWriteFile", () => {
+    it("should write string content successfully", () => {
+      (fs.writeFileSync as jest.Mock).mockImplementation(() => {});
+
+      safeWriteFile("test.txt", "content");
+
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        "test.txt",
+        "content",
+        undefined
+      );
+    });
+
+    it("should convert object to JSON when writing", () => {
+      const obj = { key: "value" };
+      (fs.writeFileSync as jest.Mock).mockImplementation(() => {});
+
+      safeWriteFile("test.json", obj);
+
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        "test.json",
+        JSON.stringify(obj, null, 2),
+        undefined
+      );
+    });
+
+    it("should handle errors when writing file", () => {
+      const mockError = new Error("Permission denied");
+      (fs.writeFileSync as jest.Mock).mockImplementation(() => {
+        throw mockError;
+      });
+
+      safeWriteFile("protected.txt", "content");
+
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        "protected.txt",
+        "content",
+        undefined
+      );
+      expect(handleError).toHaveBeenCalledWith({
+        context: "Failed to write to file at protected.txt",
+        error: mockError,
+        shouldThrow: true,
+      });
+    });
+  });
+
+  describe("safeMkdir", () => {
+    it("should create a directory successfully", () => {
+      (fs.mkdirSync as jest.Mock).mockImplementation(() => {});
+
+      safeMkdir("testdir");
+
+      expect(fs.mkdirSync).toHaveBeenCalledWith("testdir", { recursive: true });
+    });
+
+    it("should ignore error if directory already exists", () => {
+      const mockError = new Error("Directory exists");
+      Object.defineProperty(mockError, "code", { value: "EEXIST" });
+
+      (fs.mkdirSync as jest.Mock).mockImplementation(() => {
+        throw mockError;
+      });
+
+      safeMkdir("existingdir");
+
+      expect(fs.mkdirSync).toHaveBeenCalledWith("existingdir", {
+        recursive: true,
+      });
+      expect(handleError).not.toHaveBeenCalled();
+    });
+
+    it("should handle other mkdir errors", () => {
+      const mockError = new Error("Permission denied");
+      (fs.mkdirSync as jest.Mock).mockImplementation(() => {
+        throw mockError;
+      });
+
+      safeMkdir("protecteddir");
+
+      expect(fs.mkdirSync).toHaveBeenCalledWith("protecteddir", {
+        recursive: true,
+      });
+      expect(handleError).toHaveBeenCalledWith({
+        context: "Failed to create directory at protecteddir",
+        error: mockError,
+        shouldThrow: true,
+      });
+    });
+  });
+
+  describe("safeExists", () => {
+    it("should return true when file exists", () => {
+      (fs.existsSync as jest.Mock).mockReturnValue(true);
+
+      const result = safeExists("existing.txt");
+
+      expect(result).toBe(true);
+      expect(fs.existsSync).toHaveBeenCalledWith("existing.txt");
+    });
+
+    it("should return false when file doesn't exist", () => {
+      (fs.existsSync as jest.Mock).mockReturnValue(false);
+
+      const result = safeExists("nonexistent.txt");
+
+      expect(result).toBe(false);
+      expect(fs.existsSync).toHaveBeenCalledWith("nonexistent.txt");
+    });
+
+    it("should handle errors when checking existence", () => {
+      const mockError = new Error("Path error");
+      (fs.existsSync as jest.Mock).mockImplementation(() => {
+        throw mockError;
+      });
+
+      const result = safeExists("bad/path");
+
+      expect(result).toBe(false);
+      expect(fs.existsSync).toHaveBeenCalledWith("bad/path");
+      expect(handleError).toHaveBeenCalledWith({
+        context: "Failed to check if path exists at bad/path",
+        error: mockError,
+        shouldThrow: false,
+      });
+    });
+  });
+
+  describe("safeReadJson", () => {
+    it("should read and parse JSON file successfully", () => {
+      const jsonObj = { key: "value" };
+      const jsonStr = JSON.stringify(jsonObj);
+
+      // Mock safeReadFile to return the JSON string
+      (fs.readFileSync as jest.Mock).mockReturnValue(jsonStr);
+
+      const result = safeReadJson("test.json");
+
+      expect(result).toEqual(jsonObj);
+      expect(fs.readFileSync).toHaveBeenCalledWith("test.json", {
+        encoding: "utf-8",
+      });
+    });
+
+    it("should handle JSON parsing errors", () => {
+      const invalidJson = "{invalid: json}";
+      (fs.readFileSync as jest.Mock).mockReturnValue(invalidJson);
+
+      safeReadJson("invalid.json");
+
+      // First call is for safeReadFile, which succeeds, but parsing fails
+      expect(fs.readFileSync).toHaveBeenCalledWith("invalid.json", {
+        encoding: "utf-8",
+      });
+      expect(handleError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          context: "Failed to parse JSON from file at invalid.json",
+          shouldThrow: true,
+        })
+      );
+    });
+  });
+
+  describe("safeUnlink", () => {
+    it("should delete a file successfully", () => {
+      (fs.unlinkSync as jest.Mock).mockImplementation(() => {});
+
+      safeUnlink("test.txt");
+
+      expect(fs.unlinkSync).toHaveBeenCalledWith("test.txt");
+    });
+
+    it("should handle errors when deleting a file", () => {
+      const mockError = new Error("No such file");
+      (fs.unlinkSync as jest.Mock).mockImplementation(() => {
+        throw mockError;
+      });
+
+      safeUnlink("nonexistent.txt");
+
+      expect(fs.unlinkSync).toHaveBeenCalledWith("nonexistent.txt");
+      expect(handleError).toHaveBeenCalledWith({
+        context: "Failed to delete file at nonexistent.txt",
+        error: mockError,
+        shouldThrow: true,
+      });
+    });
+  });
+
+  describe("safeReadDir", () => {
+    it("should read directory contents successfully", () => {
+      const mockFiles = ["file1.txt", "file2.txt"];
+      (fs.readdirSync as jest.Mock).mockReturnValue(mockFiles);
+
+      const result = safeReadDir("testdir");
+
+      expect(result).toEqual(mockFiles);
+      expect(fs.readdirSync).toHaveBeenCalledWith("testdir");
+    });
+
+    it("should handle errors when reading a directory", () => {
+      const mockError = new Error("Directory not found");
+      (fs.readdirSync as jest.Mock).mockImplementation(() => {
+        throw mockError;
+      });
+
+      safeReadDir("nonexistent-dir");
+
+      expect(fs.readdirSync).toHaveBeenCalledWith("nonexistent-dir");
+      expect(handleError).toHaveBeenCalledWith({
+        context: "Failed to read directory at nonexistent-dir",
+        error: mockError,
+        shouldThrow: true,
+      });
+    });
+  });
+});

--- a/test/keyPaths.test.ts
+++ b/test/keyPaths.test.ts
@@ -7,6 +7,7 @@ import {
   jest,
 } from "@jest/globals";
 import os from "os";
+import path from "path";
 
 import {
   getAccountKeyPath,
@@ -34,7 +35,7 @@ describe("keyPaths", () => {
 
   describe("getKeysBaseDir", () => {
     it("should return the correct base directory path", () => {
-      const expected = `${mockHomedir}/.zetachain/keys`;
+      const expected = path.join(mockHomedir, ".zetachain", "keys");
       const result = getKeysBaseDir();
 
       expect(result).toBe(expected);
@@ -44,7 +45,7 @@ describe("keyPaths", () => {
 
   describe("getAccountTypeDir", () => {
     it("should return the correct directory for EVM account type", () => {
-      const expected = `${mockHomedir}/.zetachain/keys/evm`;
+      const expected = path.join(mockHomedir, ".zetachain", "keys", "evm");
       const result = getAccountTypeDir("evm");
 
       expect(result).toBe(expected);
@@ -52,7 +53,7 @@ describe("keyPaths", () => {
     });
 
     it("should return the correct directory for Solana account type", () => {
-      const expected = `${mockHomedir}/.zetachain/keys/solana`;
+      const expected = path.join(mockHomedir, ".zetachain", "keys", "solana");
       const result = getAccountTypeDir("solana");
 
       expect(result).toBe(expected);
@@ -63,7 +64,13 @@ describe("keyPaths", () => {
   describe("getAccountKeyPath", () => {
     it("should return the correct file path for an EVM account", () => {
       const accountName = "myaccount";
-      const expected = `${mockHomedir}/.zetachain/keys/evm/${accountName}.json`;
+      const expected = path.join(
+        mockHomedir,
+        ".zetachain",
+        "keys",
+        "evm",
+        `${accountName}.json`
+      );
       const result = getAccountKeyPath("evm", accountName);
 
       expect(result).toBe(expected);
@@ -72,7 +79,13 @@ describe("keyPaths", () => {
 
     it("should return the correct file path for a Solana account", () => {
       const accountName = "myaccount";
-      const expected = `${mockHomedir}/.zetachain/keys/solana/${accountName}.json`;
+      const expected = path.join(
+        mockHomedir,
+        ".zetachain",
+        "keys",
+        "solana",
+        `${accountName}.json`
+      );
       const result = getAccountKeyPath("solana", accountName);
 
       expect(result).toBe(expected);

--- a/test/keyPaths.test.ts
+++ b/test/keyPaths.test.ts
@@ -1,0 +1,82 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+import os from "os";
+
+import {
+  getAccountKeyPath,
+  getAccountTypeDir,
+  getKeysBaseDir,
+} from "../utils/keyPaths";
+
+// Mock the os.homedir function
+jest.mock("os", () => ({
+  homedir: jest.fn(),
+}));
+
+describe("keyPaths", () => {
+  const mockHomedir = "/mock/home/directory";
+
+  beforeEach(() => {
+    // Set up the mock to return a predictable home directory
+    (os.homedir as jest.Mock).mockReturnValue(mockHomedir);
+  });
+
+  afterEach(() => {
+    // Clear all mocks after each test
+    jest.clearAllMocks();
+  });
+
+  describe("getKeysBaseDir", () => {
+    it("should return the correct base directory path", () => {
+      const expected = `${mockHomedir}/.zetachain/keys`;
+      const result = getKeysBaseDir();
+
+      expect(result).toBe(expected);
+      expect(os.homedir).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("getAccountTypeDir", () => {
+    it("should return the correct directory for EVM account type", () => {
+      const expected = `${mockHomedir}/.zetachain/keys/evm`;
+      const result = getAccountTypeDir("evm");
+
+      expect(result).toBe(expected);
+      expect(os.homedir).toHaveBeenCalledTimes(1);
+    });
+
+    it("should return the correct directory for Solana account type", () => {
+      const expected = `${mockHomedir}/.zetachain/keys/solana`;
+      const result = getAccountTypeDir("solana");
+
+      expect(result).toBe(expected);
+      expect(os.homedir).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("getAccountKeyPath", () => {
+    it("should return the correct file path for an EVM account", () => {
+      const accountName = "myaccount";
+      const expected = `${mockHomedir}/.zetachain/keys/evm/${accountName}.json`;
+      const result = getAccountKeyPath("evm", accountName);
+
+      expect(result).toBe(expected);
+      expect(os.homedir).toHaveBeenCalledTimes(1);
+    });
+
+    it("should return the correct file path for a Solana account", () => {
+      const accountName = "myaccount";
+      const expected = `${mockHomedir}/.zetachain/keys/solana/${accountName}.json`;
+      const result = getAccountKeyPath("solana", accountName);
+
+      expect(result).toBe(expected);
+      expect(os.homedir).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/test/validateTaskArgs.test.ts
+++ b/test/validateTaskArgs.test.ts
@@ -31,7 +31,12 @@ describe("validateTaskArgs", () => {
       name: "Test User", // Type error: string instead of number
     };
 
-    expect(() => validateTaskArgs(args, schema)).to.throw(/Invalid arguments:/);
+    expect(() =>
+      validateTaskArgs(args, schema, {
+        exitOnError: false,
+        shouldLogError: false,
+      })
+    ).to.throw("age: Expected number, received string");
   });
 
   it("should handle optional fields correctly", () => {

--- a/types/accounts.types.ts
+++ b/types/accounts.types.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { evmAddressSchema } from "../types/shared.schema";
+
 export interface AccountData {
   [key: string]: string | undefined;
 }
@@ -10,18 +12,6 @@ export interface AccountInfo {
   type: string;
 }
 
-export interface EVMAccountData {
-  address: string;
-  mnemonic?: string;
-  name?: string;
-  privateKey: string;
-}
-
-export interface SolanaAccountData {
-  name?: string;
-  publicKey: string;
-  secretKey: string;
-}
 export interface AccountDetails {
   [key: string]: string;
 }
@@ -30,7 +20,7 @@ export const AvailableAccountTypes = ["evm", "solana"] as const;
 
 // Define schemas for account data types
 const evmAccountDataSchema = z.object({
-  address: z.string(),
+  address: evmAddressSchema,
   mnemonic: z.string().optional(),
   name: z.string().optional(),
   privateKey: z.string(),
@@ -41,6 +31,9 @@ const solanaAccountDataSchema = z.object({
   publicKey: z.string(),
   secretKey: z.string(),
 });
+
+export type EVMAccountData = z.infer<typeof evmAccountDataSchema>;
+export type SolanaAccountData = z.infer<typeof solanaAccountDataSchema>;
 
 // Union schema for both account types
 export const accountDataSchema = z.union([

--- a/types/accounts.types.ts
+++ b/types/accounts.types.ts
@@ -1,0 +1,25 @@
+export interface AccountData {
+  [key: string]: string | undefined;
+}
+
+export interface AccountInfo {
+  Address: string;
+  Name: string;
+  Type: string;
+}
+
+export interface EVMAccountData {
+  address: string;
+  mnemonic?: string;
+  name?: string;
+  privateKey: string;
+}
+
+export interface SolanaAccountData {
+  name?: string;
+  publicKey: string;
+  secretKey: string;
+}
+export interface AccountDetails {
+  [key: string]: string;
+}

--- a/types/accounts.types.ts
+++ b/types/accounts.types.ts
@@ -23,3 +23,5 @@ export interface SolanaAccountData {
 export interface AccountDetails {
   [key: string]: string;
 }
+
+export const AvailableAccountTypes = ["evm", "solana"] as const;

--- a/types/accounts.types.ts
+++ b/types/accounts.types.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 export interface AccountData {
   [key: string]: string | undefined;
 }
@@ -25,3 +27,23 @@ export interface AccountDetails {
 }
 
 export const AvailableAccountTypes = ["evm", "solana"] as const;
+
+// Define schemas for account data types
+const evmAccountDataSchema = z.object({
+  address: z.string(),
+  mnemonic: z.string().optional(),
+  name: z.string().optional(),
+  privateKey: z.string(),
+});
+
+const solanaAccountDataSchema = z.object({
+  name: z.string().optional(),
+  publicKey: z.string(),
+  secretKey: z.string(),
+});
+
+// Union schema for both account types
+export const accountDataSchema = z.union([
+  evmAccountDataSchema,
+  solanaAccountDataSchema,
+]);

--- a/types/accounts.types.ts
+++ b/types/accounts.types.ts
@@ -40,3 +40,8 @@ export const accountDataSchema = z.union([
   evmAccountDataSchema,
   solanaAccountDataSchema,
 ]);
+
+export const accountNameSchema = z
+  .string()
+  .min(1, "Account name is required")
+  .regex(/^[a-zA-Z0-9]+$/, "Account name can only contain letters and numbers");

--- a/types/accounts.types.ts
+++ b/types/accounts.types.ts
@@ -3,9 +3,9 @@ export interface AccountData {
 }
 
 export interface AccountInfo {
-  Address: string;
-  Name: string;
-  Type: string;
+  address: string;
+  name: string;
+  type: string;
 }
 
 export interface EVMAccountData {

--- a/utils/fsUtils.ts
+++ b/utils/fsUtils.ts
@@ -1,0 +1,151 @@
+import fs from "fs";
+
+import { handleError } from "./handleError";
+
+/**
+ * Safely reads a file with proper error handling
+ * @param path Path to the file to read
+ * @param encoding File encoding (default: 'utf-8')
+ * @returns Contents of the file
+ */
+export const safeReadFile = (
+  path: string,
+  encoding: BufferEncoding = "utf-8"
+): string => {
+  try {
+    return fs.readFileSync(path, { encoding });
+  } catch (error) {
+    handleError({
+      context: `Failed to read file at ${path}`,
+      error,
+      shouldThrow: true,
+    });
+    // This won't be reached due to shouldThrow, but needed for type checking
+    return "";
+  }
+};
+
+/**
+ * Safely writes data to a file with proper error handling
+ * @param path Path to the file to write
+ * @param data Data to write to the file
+ * @param options Write file options
+ */
+export const safeWriteFile = (
+  path: string,
+  data: string | Buffer | object,
+  options?: fs.WriteFileOptions
+): void => {
+  try {
+    // Handle objects by converting to JSON
+    const content =
+      typeof data === "object" && !(data instanceof Buffer)
+        ? JSON.stringify(data, null, 2)
+        : data;
+
+    fs.writeFileSync(path, content, options);
+  } catch (error) {
+    handleError({
+      context: `Failed to write to file at ${path}`,
+      error,
+      shouldThrow: true,
+    });
+  }
+};
+
+/**
+ * Safely creates a directory with proper error handling
+ * @param path Path to the directory to create
+ * @param options Directory creation options
+ */
+export const safeMkdir = (
+  path: string,
+  options = { recursive: true }
+): void => {
+  try {
+    fs.mkdirSync(path, options);
+  } catch (error) {
+    // Don't throw if directory already exists
+    if (error instanceof Error && "code" in error && error.code === "EEXIST") {
+      return;
+    }
+
+    handleError({
+      context: `Failed to create directory at ${path}`,
+      error,
+      shouldThrow: true,
+    });
+  }
+};
+
+/**
+ * Safely checks if a file or directory exists
+ * @param path Path to check
+ * @returns True if the path exists, false otherwise
+ */
+export const safeExists = (path: string): boolean => {
+  try {
+    return fs.existsSync(path);
+  } catch (error) {
+    handleError({
+      context: `Failed to check if path exists at ${path}`,
+      error,
+      shouldThrow: false,
+    });
+    return false;
+  }
+};
+
+/**
+ * Safely deletes a file with proper error handling
+ * @param path Path to the file to delete
+ */
+export const safeUnlink = (path: string): void => {
+  try {
+    fs.unlinkSync(path);
+  } catch (error) {
+    handleError({
+      context: `Failed to delete file at ${path}`,
+      error,
+      shouldThrow: true,
+    });
+  }
+};
+
+/**
+ * Safely reads a directory with proper error handling
+ * @param path Path to the directory to read
+ * @returns Array of directory contents
+ */
+export const safeReadDir = (path: string): string[] => {
+  try {
+    return fs.readdirSync(path);
+  } catch (error) {
+    handleError({
+      context: `Failed to read directory at ${path}`,
+      error,
+      shouldThrow: true,
+    });
+    return [];
+  }
+};
+
+/**
+ * Safely reads and parses a JSON file
+ * @param path Path to the JSON file
+ * @returns Parsed JSON object
+ */
+export const safeReadJson = <T = unknown>(path: string): T => {
+  const content = safeReadFile(path);
+  try {
+    return JSON.parse(content) as T;
+  } catch (error) {
+    handleError({
+      context: `Failed to parse JSON from file at ${path}`,
+      error,
+      shouldThrow: true,
+    });
+    // This won't be reached due to shouldThrow, but needed for type checking
+    return {} as T;
+  }
+};

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -4,6 +4,7 @@ export * from "./compareBigIntAndNumber";
 export * from "./formatting";
 export * from "./getHardhatConfig";
 export * from "./handleError";
+export * from "./keyPaths";
 export * from "./parseAbiValues";
 export * from "./parseJson";
 export * from "./safeAwait";

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -2,6 +2,7 @@ export * from "./api";
 export * from "./bitsize";
 export * from "./compareBigIntAndNumber";
 export * from "./formatting";
+export * from "./fsUtils";
 export * from "./getHardhatConfig";
 export * from "./handleError";
 export * from "./keyPaths";

--- a/utils/keyPaths.ts
+++ b/utils/keyPaths.ts
@@ -1,0 +1,35 @@
+import os from "os";
+import path from "path";
+
+import { AvailableAccountTypes } from "../types/accounts.types";
+
+/**
+ * Base directory for all account keys
+ */
+export const getKeysBaseDir = (): string => {
+  return path.join(os.homedir(), ".zetachain", "keys");
+};
+
+/**
+ * Get the directory for a specific account type
+ * @param type Account type (evm, solana, etc.)
+ * @returns Directory path for the specified account type
+ */
+export const getAccountTypeDir = (
+  type: (typeof AvailableAccountTypes)[number]
+): string => {
+  return path.join(getKeysBaseDir(), type);
+};
+
+/**
+ * Get the file path for a specific account
+ * @param type Account type (evm, solana, etc.)
+ * @param name Account name
+ * @returns File path for the specified account
+ */
+export const getAccountKeyPath = (
+  type: (typeof AvailableAccountTypes)[number],
+  name: string
+): string => {
+  return path.join(getAccountTypeDir(type), `${name}.json`);
+};

--- a/utils/validateTaskArgs.ts
+++ b/utils/validateTaskArgs.ts
@@ -19,6 +19,9 @@ const formatZodError = (error: z.ZodError): string => {
  * @template U - The type of the Zod schema input
  * @param args - The unvalidated task arguments
  * @param schema - The Zod schema to validate against
+ * @param options - Optional configuration
+ * @param options.exitOnError - Whether to exit the process on validation failure (default: false)
+ * @param options.shouldLogError - Whether to log the error message to console (default: true)
  * @returns The validated and parsed arguments
  * @throws Error if validation fails
  */

--- a/utils/validateTaskArgs.ts
+++ b/utils/validateTaskArgs.ts
@@ -1,6 +1,18 @@
 import { z } from "zod";
 
 /**
+ * Formats Zod validation errors into a user-friendly message
+ */
+const formatZodError = (error: z.ZodError): string => {
+  const errors = error.errors.map((err) => {
+    const path = err.path.join(".");
+    return path ? `${path}: ${err.message}` : err.message;
+  });
+
+  return errors.join("\n");
+};
+
+/**
  * Validates task arguments against a Zod schema
  *
  * @template T - The type of the Zod schema output
@@ -17,7 +29,9 @@ export const validateTaskArgs = <T, U = T>(
   const result = schema.safeParse(args);
 
   if (!result.success) {
-    throw new Error(`Invalid arguments: ${result.error.message}`);
+    const errorMessage = formatZodError(result.error);
+    console.error(`\x1b[31m${errorMessage}\x1b[0m`);
+    process.exit(1);
   }
 
   return result.data;

--- a/utils/validateTaskArgs.ts
+++ b/utils/validateTaskArgs.ts
@@ -24,14 +24,32 @@ const formatZodError = (error: z.ZodError): string => {
  */
 export const validateTaskArgs = <T, U = T>(
   args: unknown,
-  schema: z.ZodType<T, z.ZodTypeDef, U>
+  schema: z.ZodType<T, z.ZodTypeDef, U>,
+  options?: {
+    exitOnError?: boolean;
+    shouldLogError?: boolean;
+  }
 ): T => {
+  // Merge with defaults properly - this ensures partial options don't lose default values
+  const mergedOptions = {
+    exitOnError: false,
+    shouldLogError: true,
+    ...options,
+  };
+
   const result = schema.safeParse(args);
 
   if (!result.success) {
     const errorMessage = formatZodError(result.error);
-    console.error(`\x1b[31m${errorMessage}\x1b[0m`);
-    process.exit(1);
+    if (mergedOptions.shouldLogError) {
+      console.error(`\x1b[31m${errorMessage}\x1b[0m`);
+    }
+
+    if (mergedOptions.exitOnError) {
+      process.exit(1);
+    } else {
+      throw new Error(errorMessage);
+    }
   }
 
   return result.data;


### PR DESCRIPTION
```bash
yarn zetachain accounts create --name alice # create accounts for all chains

yarn zetachain accounts create --name bob --type solana # create account for Solana only

yarn zetachain accounts show --name alice

yarn zetachain accounts list

yarn zetachain accounts delete --name bob --type solana
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added CLI commands to create, delete, list, and show blockchain accounts for EVM and Solana.
  - Introduced a centralized account management command group in the CLI toolkit.
- **Chores**
  - Updated CLI scripts to separate build-and-run and direct TypeScript execution commands.
- **Tests**
  - Refined validation test expectations for more precise error messages.
  - Added tests for account key path utilities ensuring correct filesystem paths.
  - Added comprehensive tests for filesystem utility functions covering success and error scenarios.
- **Documentation**
  - Enhanced error formatting and logging for schema validation failures.
- **New Utilities**
  - Introduced safe filesystem operation utilities with consistent error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->