### PR TITLE
chore: export commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "",
   "exports": {
     "./tasks": "./dist/packages/tasks/src/index.js",
+    "./commands": "./dist/packages/commands/src/index.js",
     "./client": {
       "import": "./dist/packages/client/src/index.js",
       "require": "./dist/packages/client/src/index.js",

--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -1,11 +1,2 @@
-import { Command } from "commander";
-
-import { accountsCommand } from "./accounts";
-import { solanaEncodeCommand } from "./solanaEncode";
-
-export const toolkitCommand = new Command("toolkit")
-  .description("Local development environment")
-  .helpCommand(false);
-
-toolkitCommand.addCommand(solanaEncodeCommand);
-toolkitCommand.addCommand(accountsCommand);
+export * from "./accounts";
+export * from "./solana";

--- a/packages/commands/src/program.ts
+++ b/packages/commands/src/program.ts
@@ -1,4 +1,14 @@
 #!/usr/bin/env node
-import { toolkitCommand } from ".";
+import { Command } from "commander";
+
+import { accountsCommand } from "./accounts";
+import { solanaCommand } from "./solana";
+
+export const toolkitCommand = new Command("toolkit")
+  .description("Local development environment")
+  .helpCommand(false);
+
+toolkitCommand.addCommand(accountsCommand);
+toolkitCommand.addCommand(solanaCommand);
 
 toolkitCommand.parse(process.argv);

--- a/packages/commands/src/solana/encode.ts
+++ b/packages/commands/src/solana/encode.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 
-import { EncodeOptions, solanaEncode } from "../../client/src/solanaEncode";
+import { EncodeOptions, solanaEncode } from "../../../client/src/solanaEncode";
 
 const main = async (options: EncodeOptions) => {
   try {
@@ -12,7 +12,7 @@ const main = async (options: EncodeOptions) => {
   }
 };
 
-export const solanaEncodeCommand = new Command("encode")
+export const encodeCommand = new Command("encode")
   .description("Encode payload data for Solana")
   .requiredOption("--connected <address>", "Connected PDA account address")
   .requiredOption("--data <data>", "Data to encode")

--- a/packages/commands/src/solana/index.ts
+++ b/packages/commands/src/solana/index.ts
@@ -1,0 +1,9 @@
+import { Command } from "commander";
+
+import { encodeCommand } from "./encode";
+
+export const solanaCommand = new Command("solana").description(
+  "Solana commands"
+);
+
+solanaCommand.addCommand(encodeCommand);


### PR DESCRIPTION
* Export commands so that they can be imported by the CLI
* Move Solana encode command in the Solana namespace

The CLI will import commands like so:

```ts
import { accountsCommand, solanaCommand } from "@zetachain/toolkit/commands";
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new command group for Solana-related commands, organizing them under a unified namespace in the CLI.

- **Refactor**
  - Simplified the command structure by re-exporting modules directly and restructuring how commands are composed and organized.
  - Updated the naming of exported commands for clarity and consistency.

- **Chores**
  - Updated the package configuration to add a new export entry for commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->