### PR TITLE
feat: fetch balances for Testnet 4 and Signet

### DIFF
--- a/packages/client/src/getBalances.ts
+++ b/packages/client/src/getBalances.ts
@@ -106,7 +106,7 @@ export const getBalances = async function (
 
   // Step 4: Get BTC balances
   if (btcAddress) {
-    const btcBalances = await getBtcBalances(tokens, btcAddress, getEndpoint);
+    const btcBalances = await getBtcBalances(tokens, btcAddress);
     balances = balances.concat(btcBalances);
   }
 

--- a/test/balances.test.ts
+++ b/test/balances.test.ts
@@ -487,14 +487,19 @@ describe("balances utility functions", () => {
 
   describe("getBtcBalances", () => {
     it("should fetch and calculate BTC balances", async () => {
-      // Setup axios mock for BTC balance
       axios.get.mockResolvedValue({
-        data: {
-          chain_stats: {
-            funded_txo_sum: "200000000", // 2 BTC
-            spent_txo_sum: "100000000", // 1 BTC
+        data: [
+          {
+            txid: "tx1",
+            value: 100000000, // 1 BTC
+            vout: 0,
           },
-        },
+          {
+            txid: "tx2",
+            value: 50000000, // 0.5 BTC
+            vout: 1,
+          },
+        ],
       });
 
       const mockTokens = [
@@ -509,17 +514,13 @@ describe("balances utility functions", () => {
 
       const mockBtcAddress = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
 
-      const mockGetEndpoint = createMockGetEndpoint({
-        esplora: { btc_mainnet: "https://blockstream.info/api" },
-      });
-
       const result = await balancesUtils.getBtcBalances(
         mockTokens,
         mockBtcAddress
       );
 
       expect(result).toHaveLength(1);
-      expect(result[0].balance).toBe("1"); // 2 BTC - 1 BTC = 1 BTC
+      expect(result[0].balance).toBe("1.50000000"); // 1.5 BTC total
       expect(result[0].symbol).toBe("BTC");
     });
   });

--- a/test/balances.test.ts
+++ b/test/balances.test.ts
@@ -515,8 +515,7 @@ describe("balances utility functions", () => {
 
       const result = await balancesUtils.getBtcBalances(
         mockTokens,
-        mockBtcAddress,
-        mockGetEndpoint
+        mockBtcAddress
       );
 
       expect(result).toHaveLength(1);

--- a/types/balances.types.ts
+++ b/types/balances.types.ts
@@ -84,10 +84,3 @@ type AggregateResult = [blockNumber: bigint, returnData: string[]];
 export interface MulticallContract extends OmitIndexSignature<Contract> {
   aggregate?: ContractMethod<[calls: Call[]], AggregateResult, AggregateResult>;
 }
-
-export interface EsploraResponse {
-  chain_stats: {
-    funded_txo_sum: string;
-    spent_txo_sum: string;
-  };
-}

--- a/utils/balances.ts
+++ b/utils/balances.ts
@@ -432,11 +432,11 @@ export const getBtcBalances = async (
     try {
       let network = "";
       if (token.chain_name === "btc_signet_testnet") {
-        network = "signet";
+        network = "/signet";
       } else if (token.chain_name === "btc_testnet4") {
-        network = "testnet4";
+        network = "/testnet4";
       }
-      const API = `https://mempool.space/${network}/api`;
+      const API = `https://mempool.space${network}/api`;
       const utxos = (
         await axios.get<UTXO[]>(`${API}/address/${btcAddress}/utxo`)
       ).data;

--- a/utils/balances.ts
+++ b/utils/balances.ts
@@ -455,8 +455,14 @@ export const getBtcBalances = async (
           balance,
           id: parseTokenId(token.chain_id?.toString() || "", token.symbol),
         });
-      } else if (token.chain_name === "btc_signet_testnet") {
-        const API = "https://mempool.space/signet/api";
+      } else if (
+        token.chain_name === "btc_signet_testnet" ||
+        token.chain_name === "btc_testnet4"
+      ) {
+        const API =
+          token.chain_name === "btc_signet_testnet"
+            ? "https://mempool.space/signet/api"
+            : "https://mempool.space/testnet4/api";
         const utxos = (
           await axios.get<UTXO[]>(`${API}/address/${btcAddress}/utxo`)
         ).data;
@@ -467,7 +473,7 @@ export const getBtcBalances = async (
           inTotal += u.value;
           picks.push(u);
         }
-        const balance = inTotal.toString();
+        const balance = (inTotal / 100000000).toFixed(8);
         balances.push({
           ...token,
           balance,

--- a/utils/balances.ts
+++ b/utils/balances.ts
@@ -6,7 +6,6 @@ import { AbiCoder, ethers } from "ethers";
 
 import {
   Call,
-  EsploraResponse,
   MULTICALL3_ABI,
   MulticallContract,
   RpcSolTokenByAccountResponse,


### PR DESCRIPTION
* Added support for Testnet 4 and Signet
* Use mempool.space as it supports all three networks
* Use the same logic for calculating balances for all three networks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved accuracy of Bitcoin balance calculations by aggregating unspent transaction outputs (UTXOs) instead of relying on previous chain statistics.
- **Refactor**
	- Updated the method for fetching Bitcoin balances to use a fixed API endpoint, enhancing reliability and consistency.
- **Tests**
	- Updated test cases to reflect the new balance calculation method and data format.
- **Chores**
	- Removed unused types and streamlined internal type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->