### PR TITLE
fix: remove help command

### DIFF
--- a/packages/commands/src/accounts/index.ts
+++ b/packages/commands/src/accounts/index.ts
@@ -10,4 +10,5 @@ export const accountsCommand = new Command("accounts")
   .addCommand(createAccountsCommand)
   .addCommand(showAccountsCommand)
   .addCommand(listAccountsCommand)
-  .addCommand(deleteAccountsCommand);
+  .addCommand(deleteAccountsCommand)
+  .helpCommand(false);

--- a/packages/commands/src/solana/index.ts
+++ b/packages/commands/src/solana/index.ts
@@ -6,4 +6,4 @@ export const solanaCommand = new Command("solana").description(
   "Solana commands"
 );
 
-solanaCommand.addCommand(encodeCommand);
+solanaCommand.addCommand(encodeCommand).helpCommand(false);

--- a/packages/commands/src/sui/index.ts
+++ b/packages/commands/src/sui/index.ts
@@ -4,4 +4,4 @@ import { encodeCommand } from "./encode";
 
 export const suiCommand = new Command("sui").description("Sui commands");
 
-suiCommand.addCommand(encodeCommand);
+suiCommand.addCommand(encodeCommand).helpCommand(false);


### PR DESCRIPTION
`--help` flag should be used instead.

Related: https://github.com/zeta-chain/cli/pull/16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Disabled automatic help subcommands for specific commands in the accounts, Solana, and Sui command-line interfaces. The help subcommand will no longer appear for these commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->