### PR TITLE
feat: evm deposit and call command

### DIFF
--- a/packages/commands/src/evm/common.ts
+++ b/packages/commands/src/evm/common.ts
@@ -1,0 +1,210 @@
+import confirm from "@inquirer/confirm";
+import { Command, Option } from "commander";
+import { ethers, ZeroAddress } from "ethers";
+import { z } from "zod";
+
+import { EVMAccountData } from "../../../../types/accounts.types";
+import { DEFAULT_ACCOUNT_NAME } from "../../../../types/shared.constants";
+import {
+  evmAddressSchema,
+  evmPrivateKeySchema,
+  numericStringSchema,
+  validAmountSchema,
+} from "../../../../types/shared.schema";
+import { handleError, printEvmTransactionDetails } from "../../../../utils";
+import { getAccountData } from "../../../../utils/accounts";
+import { hasSufficientBalanceEvm } from "../../../../utils/balances";
+import { getRpcUrl } from "../../../../utils/chains";
+import { ZetaChainClient } from "../../../client/src/client";
+
+export const baseEvmDepositOptionsSchema = z.object({
+  abortAddress: evmAddressSchema,
+  amount: validAmountSchema,
+  callOnRevert: z.boolean().default(false),
+  chainId: numericStringSchema,
+  erc20: evmAddressSchema.optional(),
+  gasLimit: numericStringSchema.optional(),
+  gasPrice: numericStringSchema.optional(),
+  gateway: evmAddressSchema.optional(),
+  name: z.string().default(DEFAULT_ACCOUNT_NAME),
+  network: z.enum(["mainnet", "testnet"]).default("testnet"),
+  onRevertGasLimit: numericStringSchema.default("200000"),
+  privateKey: evmPrivateKeySchema.optional(),
+  receiver: evmAddressSchema,
+  revertAddress: evmAddressSchema.optional(),
+  revertMessage: z.string().default(""),
+  rpc: z.string().url().optional(),
+  yes: z.boolean().default(false),
+});
+
+type EvmDepositOptions = z.infer<typeof baseEvmDepositOptionsSchema>;
+
+// Common setup function for both deposit commands
+export const setupTransaction = async (options: EvmDepositOptions) => {
+  const chainId = parseInt(options.chainId);
+  const networkType = options.network;
+  const rpcUrl = options.rpc || getRpcUrl(chainId);
+  const provider = new ethers.JsonRpcProvider(rpcUrl);
+
+  const privateKey =
+    options.privateKey ||
+    getAccountData<EVMAccountData>("evm", options.name)?.privateKey;
+
+  if (!privateKey) {
+    const errorMessage = handleError({
+      context: "Failed to retrieve private key",
+      error: new Error("Private key not found"),
+      shouldThrow: false,
+    });
+
+    throw new Error(errorMessage);
+  }
+
+  let signer: ethers.Wallet;
+
+  try {
+    signer = new ethers.Wallet(privateKey, provider);
+  } catch (error) {
+    const errorMessage = handleError({
+      context: "Failed to create signer from private key",
+      error,
+      shouldThrow: false,
+    });
+
+    throw new Error(errorMessage);
+  }
+
+  const client = new ZetaChainClient({ network: networkType, signer });
+
+  const { hasEnoughBalance, balance, decimals } = await hasSufficientBalanceEvm(
+    provider,
+    signer,
+    options.amount,
+    options.erc20
+  );
+
+  if (!hasEnoughBalance) {
+    handleError({
+      context: "Insufficient balance",
+      error: new Error(
+        `Required: ${options.amount}, Available: ${ethers.formatUnits(
+          balance,
+          decimals
+        )}`
+      ),
+      shouldThrow: true,
+    });
+  }
+
+  await printEvmTransactionDetails(signer, chainId, {
+    amount: options.amount,
+    callOnRevert: options.callOnRevert,
+    erc20: options.erc20,
+    onRevertGasLimit: options.onRevertGasLimit,
+    receiver: options.receiver,
+    revertMessage: options.revertMessage,
+  });
+
+  return { client, provider, signer };
+};
+
+// Common confirmation prompt for transactions
+export const confirmTransaction = async (options: EvmDepositOptions) => {
+  if (options.yes) {
+    console.log("Proceeding with transaction (--yes flag set)");
+    return true;
+  }
+
+  let confirmed;
+  try {
+    confirmed = await confirm({
+      default: true,
+      message: "Proceed with the transaction?",
+    });
+  } catch (error) {
+    console.log("\nTransaction cancelled");
+    process.exit(0);
+  }
+
+  if (!confirmed) {
+    console.log("\nTransaction cancelled");
+    process.exit(0);
+  }
+
+  return confirmed;
+};
+
+// Common revert options preparation
+export const prepareRevertOptions = (
+  options: EvmDepositOptions,
+  signer: ethers.Wallet
+) => {
+  return {
+    abortAddress: options.abortAddress,
+    callOnRevert: options.callOnRevert,
+    onRevertGasLimit: options.onRevertGasLimit,
+    revertAddress: options.revertAddress || signer.address,
+    revertMessage: options.revertMessage,
+  };
+};
+
+// Common transaction options preparation
+export const prepareTxOptions = (options: EvmDepositOptions) => {
+  return {
+    gasLimit: options.gasLimit,
+    gasPrice: options.gasPrice,
+  };
+};
+
+// Common command options setup
+export const addCommonEvmDepositCommandOptions = (command: Command) => {
+  return command
+    .requiredOption("--amount <amount>", "Amount of tokens to deposit")
+    .addOption(
+      new Option("--network <network>", "Network to use")
+        .choices(["mainnet", "testnet"])
+        .default("testnet")
+    )
+    .requiredOption("--chain-id <chainId>", "Chain ID of the network")
+    .requiredOption("--receiver <address>", "Receiver address on ZetaChain")
+    .addOption(
+      new Option("--name <name>", "Account name")
+        .default(DEFAULT_ACCOUNT_NAME)
+        .conflicts(["private-key"])
+    )
+    .addOption(
+      new Option(
+        "--private-key <key>",
+        "Private key for signing transactions"
+      ).conflicts(["name"])
+    )
+    .option("--rpc <url>", "RPC URL for the source chain")
+    .option(
+      "--erc20 <address>",
+      "ERC20 token address (optional for native token deposits)"
+    )
+    .option("--gateway <address>", "EVM Gateway address")
+    .option(
+      "--revert-address <address>",
+      "Address to revert to in case of failure (default: signer address)"
+    )
+    .option(
+      "--abort-address <address>",
+      `Address to receive funds if aborted (default: ${ZeroAddress})`,
+      ZeroAddress
+    )
+    .option(
+      "--call-on-revert",
+      "Whether to call revert address on failure",
+      false
+    )
+    .option(
+      "--on-revert-gas-limit <limit>",
+      "Gas limit for revert operation",
+      "200000"
+    )
+    .option("--revert-message <message>", "Message to include in revert", "")
+    .option("--gas-limit <limit>", "Gas limit for the transaction")
+    .option("--gas-price <price>", "Gas price for the transaction")
+    .option("--yes", "Skip confirmation prompt", false);
+};

--- a/packages/commands/src/evm/common.ts
+++ b/packages/commands/src/evm/common.ts
@@ -14,7 +14,7 @@ import {
 import { handleError, printEvmTransactionDetails } from "../../../../utils";
 import { getAccountData } from "../../../../utils/accounts";
 import { hasSufficientBalanceEvm } from "../../../../utils/balances";
-import { getRpcUrl } from "../../../../utils/chains";
+import { getNetworkTypeByChainId, getRpcUrl } from "../../../../utils/chains";
 import { ZetaChainClient } from "../../../client/src/client";
 
 export const baseEvmDepositOptionsSchema = z.object({
@@ -27,7 +27,6 @@ export const baseEvmDepositOptionsSchema = z.object({
   gasPrice: numericStringSchema.optional(),
   gateway: evmAddressSchema.optional(),
   name: z.string().default(DEFAULT_ACCOUNT_NAME),
-  network: z.enum(["mainnet", "testnet"]).default("testnet"),
   onRevertGasLimit: numericStringSchema.default("200000"),
   privateKey: evmPrivateKeySchema.optional(),
   receiver: evmAddressSchema,
@@ -42,7 +41,7 @@ type EvmDepositOptions = z.infer<typeof baseEvmDepositOptionsSchema>;
 // Common setup function for both deposit commands
 export const setupTransaction = async (options: EvmDepositOptions) => {
   const chainId = parseInt(options.chainId);
-  const networkType = options.network;
+  const networkType = getNetworkTypeByChainId(chainId);
   const rpcUrl = options.rpc || getRpcUrl(chainId);
   const provider = new ethers.JsonRpcProvider(rpcUrl);
 
@@ -160,11 +159,6 @@ export const prepareTxOptions = (options: EvmDepositOptions) => {
 export const addCommonEvmDepositCommandOptions = (command: Command) => {
   return command
     .requiredOption("--amount <amount>", "Amount of tokens to deposit")
-    .addOption(
-      new Option("--network <network>", "Network to use")
-        .choices(["mainnet", "testnet"])
-        .default("testnet")
-    )
     .requiredOption("--chain-id <chainId>", "Chain ID of the network")
     .requiredOption("--receiver <address>", "Receiver address on ZetaChain")
     .addOption(

--- a/packages/commands/src/evm/deposit.ts
+++ b/packages/commands/src/evm/deposit.ts
@@ -1,163 +1,34 @@
-import confirm from "@inquirer/confirm";
-import { Command, Option } from "commander";
-import { ethers, ZeroAddress } from "ethers";
+import { Command } from "commander";
 import { z } from "zod";
 
-import { EVMAccountData } from "../../../../types/accounts.types";
-import { DEFAULT_ACCOUNT_NAME } from "../../../../types/shared.constants";
+import { namePkRefineRule } from "../../../../types/shared.schema";
+import { handleError } from "../../../../utils";
 import {
-  evmAddressSchema,
-  evmPrivateKeySchema,
-  numericStringSchema,
-  validAmountSchema,
-} from "../../../../types/shared.schema";
-import { handleError, printEvmTransactionDetails } from "../../../../utils";
-import { getAccountData } from "../../../../utils/accounts";
-import { hasSufficientBalanceEvm } from "../../../../utils/balances";
-import { getRpcUrl } from "../../../../utils/chains";
-import { ZetaChainClient } from "../../../client/src/client";
+  addCommonEvmDepositCommandOptions,
+  baseEvmDepositOptionsSchema,
+  confirmTransaction,
+  prepareRevertOptions,
+  prepareTxOptions,
+  setupTransaction,
+} from "./common";
 
-const depositOptionsSchema = z
-  .object({
-    abortAddress: evmAddressSchema,
-    amount: validAmountSchema,
-    callOnRevert: z.boolean().default(false),
-    chainId: numericStringSchema,
-    erc20: evmAddressSchema.optional(),
-    gasLimit: numericStringSchema.optional(),
-    gasPrice: numericStringSchema.optional(),
-    gateway: evmAddressSchema.optional(),
-    name: z.string().default(DEFAULT_ACCOUNT_NAME),
-    network: z.enum(["mainnet", "testnet"]).default("testnet"),
-    onRevertGasLimit: numericStringSchema.default("200000"),
-    privateKey: evmPrivateKeySchema.optional(),
-    receiver: evmAddressSchema,
-    revertAddress: evmAddressSchema.optional(),
-    revertMessage: z.string().default(""),
-    rpc: z.string().url().optional(),
-    yes: z.boolean().default(false),
-  })
-  .refine((data) => !(data.privateKey && data.name !== DEFAULT_ACCOUNT_NAME), {
-    message: "Only one of --name or --private-key should be provided",
-    path: ["name", "privateKey"],
-  });
+const depositOptionsSchema =
+  baseEvmDepositOptionsSchema.refine(namePkRefineRule);
 
 type DepositOptions = z.infer<typeof depositOptionsSchema>;
 
 const main = async (options: DepositOptions) => {
   try {
-    const chainId = parseInt(options.chainId);
-    const networkType = options.network;
-    const rpcUrl = options.rpc || getRpcUrl(chainId);
-    const provider = new ethers.JsonRpcProvider(rpcUrl);
+    const { client, signer } = await setupTransaction(options);
 
-    const privateKey =
-      options.privateKey ||
-      getAccountData<EVMAccountData>("evm", options.name)?.privateKey;
-
-    if (!privateKey) {
-      const errorMessage = handleError({
-        context: "Failed to retrieve private key",
-        error: new Error("Private key not found"),
-        shouldThrow: false,
-      });
-
-      throw new Error(errorMessage);
-    }
-
-    const { success: isPrivateKeyValid, data: parsedPrivateKey } =
-      evmPrivateKeySchema.safeParse(privateKey);
-
-    if (!isPrivateKeyValid) {
-      const errorMessage = handleError({
-        context: "Invalid private key",
-        error: new Error("Private key is invalid"),
-        shouldThrow: false,
-      });
-
-      throw new Error(errorMessage);
-    }
-
-    let signer: ethers.Wallet;
-    try {
-      signer = new ethers.Wallet(parsedPrivateKey, provider);
-    } catch (error) {
-      const errorMessage = handleError({
-        context: "Failed to create signer from private key",
-        error,
-        shouldThrow: false,
-      });
-
-      throw new Error(errorMessage);
-    }
-
-    const client = new ZetaChainClient({ network: networkType, signer });
-
-    const { hasEnoughBalance, balance, decimals } =
-      await hasSufficientBalanceEvm(
-        provider,
-        signer,
-        options.amount,
-        options.erc20
-      );
-
-    if (!hasEnoughBalance) {
-      handleError({
-        context: "Insufficient balance",
-        error: new Error(
-          `Required: ${options.amount}, Available: ${ethers.formatUnits(
-            balance,
-            decimals
-          )}`
-        ),
-        shouldThrow: true,
-      });
-    }
-
-    await printEvmTransactionDetails(signer, chainId, {
-      amount: options.amount,
-      callOnRevert: options.callOnRevert,
-      erc20: options.erc20,
-      onRevertGasLimit: options.onRevertGasLimit,
-      receiver: options.receiver,
-      revertMessage: options.revertMessage,
-    });
-
-    if (options.yes) {
-      console.log("Proceeding with transaction (--yes flag set)");
-    } else {
-      let confirmed;
-      try {
-        confirmed = await confirm({
-          default: true,
-          message: "Proceed with the transaction?",
-        });
-      } catch (error) {
-        console.log("\nTransaction cancelled");
-        process.exit(0);
-      }
-
-      if (!confirmed) {
-        console.log("\nTransaction cancelled");
-        process.exit(0);
-      }
-    }
+    await confirmTransaction(options);
 
     const tx = await client.evmDeposit({
       amount: options.amount,
       erc20: options.erc20,
       receiver: options.receiver,
-      revertOptions: {
-        abortAddress: options.abortAddress,
-        callOnRevert: options.callOnRevert,
-        onRevertGasLimit: options.onRevertGasLimit,
-        revertAddress: options.revertAddress || signer.address,
-        revertMessage: options.revertMessage,
-      },
-      txOptions: {
-        gasLimit: options.gasLimit,
-        gasPrice: options.gasPrice,
-      },
+      revertOptions: prepareRevertOptions(options, signer),
+      txOptions: prepareTxOptions(options),
     });
     console.log("Transaction hash:", tx.hash);
   } catch (error) {
@@ -170,57 +41,11 @@ const main = async (options: DepositOptions) => {
   }
 };
 
-export const depositCommand = new Command("deposit")
-  .description("Deposit tokens to ZetaChain from an EVM-compatible chain")
-  .requiredOption("--amount <amount>", "Amount of tokens to deposit")
-  .addOption(
-    new Option("--network <network>", "Network to use")
-      .choices(["mainnet", "testnet"])
-      .default("testnet")
-  )
-  .requiredOption("--chain-id <chainId>", "Chain ID of the network")
-  .requiredOption("--receiver <address>", "Receiver address on ZetaChain")
-  .addOption(
-    new Option("--name <name>", "Account name")
-      .default(DEFAULT_ACCOUNT_NAME)
-      .conflicts(["private-key"])
-  )
-  .addOption(
-    new Option(
-      "--private-key <key>",
-      "Private key for signing transactions"
-    ).conflicts(["name"])
-  )
-  .option("--rpc <url>", "RPC URL for the source chain")
-  .option(
-    "--erc20 <address>",
-    "ERC20 token address (optional for native token deposits)"
-  )
-  .option("--gateway <address>", "EVM Gateway address")
-  .option(
-    "--revert-address <address>",
-    "Address to revert to in case of failure (default: signer address)"
-  )
-  .option(
-    "--abort-address <address>",
-    `Address to receive funds if aborted (default: ${ZeroAddress})`,
-    ZeroAddress
-  )
-  .option(
-    "--call-on-revert",
-    "Whether to call revert address on failure",
-    false
-  )
-  .option(
-    "--on-revert-gas-limit <limit>",
-    "Gas limit for revert operation",
-    "200000"
-  )
-  .option("--revert-message <message>", "Message to include in revert", "")
-  .option("--gas-limit <limit>", "Gas limit for the transaction")
-  .option("--gas-price <price>", "Gas price for the transaction")
-  .option("--yes", "Skip confirmation prompt", false)
-  .action(async (options) => {
-    const validatedOptions = depositOptionsSchema.parse(options);
-    await main(validatedOptions);
-  });
+export const depositCommand = new Command("deposit").description(
+  "Deposit tokens to ZetaChain from an EVM-compatible chain"
+);
+
+addCommonEvmDepositCommandOptions(depositCommand).action(async (options) => {
+  const validatedOptions = depositOptionsSchema.parse(options);
+  await main(validatedOptions);
+});

--- a/packages/commands/src/evm/deposit.ts
+++ b/packages/commands/src/evm/deposit.ts
@@ -21,7 +21,9 @@ const main = async (options: DepositOptions) => {
   try {
     const { client, signer } = await setupTransaction(options);
 
-    await confirmTransaction(options);
+    const isConfirmed = await confirmTransaction(options);
+
+    if (!isConfirmed) return;
 
     const tx = await client.evmDeposit({
       amount: options.amount,

--- a/packages/commands/src/evm/deposit.ts
+++ b/packages/commands/src/evm/deposit.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import { z } from "zod";
 
 import { namePkRefineRule } from "../../../../types/shared.schema";
-import { handleError } from "../../../../utils";
+import { handleError, validateAndParseSchema } from "../../../../utils";
 import {
   addCommonEvmDepositCommandOptions,
   baseEvmDepositOptionsSchema,
@@ -46,6 +46,12 @@ export const depositCommand = new Command("deposit").description(
 );
 
 addCommonEvmDepositCommandOptions(depositCommand).action(async (options) => {
-  const validatedOptions = depositOptionsSchema.parse(options);
+  const validatedOptions = validateAndParseSchema(
+    options,
+    depositOptionsSchema,
+    {
+      exitOnError: true,
+    }
+  );
   await main(validatedOptions);
 });

--- a/packages/commands/src/evm/deposit.ts
+++ b/packages/commands/src/evm/deposit.ts
@@ -10,7 +10,7 @@ import {
   prepareRevertOptions,
   prepareTxOptions,
   setupTransaction,
-} from "./common";
+} from "../../../../utils/evm.command.helpers";
 
 const depositOptionsSchema =
   baseEvmDepositOptionsSchema.refine(namePkRefineRule);

--- a/packages/commands/src/evm/depositAndCall.ts
+++ b/packages/commands/src/evm/depositAndCall.ts
@@ -79,7 +79,7 @@ export const depositAndCallCommand = new Command(
 addCommonEvmDepositCommandOptions(depositAndCallCommand)
   .requiredOption(
     "--types <types...>",
-    "JSON string array of parameter types (e.g. uint256 address)"
+    "List of parameter types (e.g. uint256 address)"
   )
   .requiredOption(
     "--values <values...>",

--- a/packages/commands/src/evm/depositAndCall.ts
+++ b/packages/commands/src/evm/depositAndCall.ts
@@ -6,7 +6,7 @@ import {
   stringArraySchema,
   typesAndValuesLengthRefineRule,
 } from "../../../../types/shared.schema";
-import { handleError } from "../../../../utils";
+import { handleError, validateAndParseSchema } from "../../../../utils";
 import {
   addCommonEvmDepositCommandOptions,
   baseEvmDepositOptionsSchema,
@@ -84,6 +84,12 @@ addCommonEvmDepositCommandOptions(depositAndCallCommand)
     "Parameter values for the function call"
   )
   .action(async (options) => {
-    const validatedOptions = depositAndCallOptionsSchema.parse(options);
+    const validatedOptions = validateAndParseSchema(
+      options,
+      depositAndCallOptionsSchema,
+      {
+        exitOnError: true,
+      }
+    );
     await main(validatedOptions);
   });

--- a/packages/commands/src/evm/depositAndCall.ts
+++ b/packages/commands/src/evm/depositAndCall.ts
@@ -42,7 +42,9 @@ Function parameters: ${options.values.join(", ")}
 Parameter types: ${stringifiedTypes}
 `);
 
-    await confirmTransaction(options);
+    const isConfirmed = await confirmTransaction(options);
+
+    if (!isConfirmed) return;
 
     const values = parseAbiValues(stringifiedTypes, options.values);
     const parsedTypes = parseJson(stringifiedTypes, stringArraySchema);

--- a/packages/commands/src/evm/depositAndCall.ts
+++ b/packages/commands/src/evm/depositAndCall.ts
@@ -1,158 +1,42 @@
-import confirm from "@inquirer/confirm";
-import { Command, Option } from "commander";
-import { ethers, ZeroAddress } from "ethers";
+import { Command } from "commander";
 import { z } from "zod";
 
-import { EVMAccountData } from "../../../../types/accounts.types";
-import { DEFAULT_ACCOUNT_NAME } from "../../../../types/shared.constants";
 import {
-  evmAddressSchema,
-  evmPrivateKeySchema,
-  numericStringSchema,
+  namePkRefineRule,
   stringArraySchema,
-  validAmountSchema,
   validJsonStringSchema,
 } from "../../../../types/shared.schema";
-import { handleError, printEvmTransactionDetails } from "../../../../utils";
-import { getAccountData } from "../../../../utils/accounts";
-import { hasSufficientBalanceEvm } from "../../../../utils/balances";
-import { getRpcUrl } from "../../../../utils/chains";
+import { handleError } from "../../../../utils";
 import { parseAbiValues } from "../../../../utils/parseAbiValues";
 import { parseJson } from "../../../../utils/parseJson";
-import { ZetaChainClient } from "../../../client/src/client";
+import {
+  addCommonEvmDepositCommandOptions,
+  baseEvmDepositOptionsSchema,
+  confirmTransaction,
+  prepareRevertOptions,
+  prepareTxOptions,
+  setupTransaction,
+} from "./common";
 
-const depositAndCallOptionsSchema = z
-  .object({
-    abortAddress: evmAddressSchema,
-    amount: validAmountSchema,
-    callOnRevert: z.boolean().default(false),
-    chainId: numericStringSchema,
-    erc20: evmAddressSchema.optional(),
-    gasLimit: numericStringSchema.optional(),
-    gasPrice: numericStringSchema.optional(),
-    gateway: evmAddressSchema.optional(),
-    name: z.string().default(DEFAULT_ACCOUNT_NAME),
-    network: z.enum(["mainnet", "testnet"]).default("testnet"),
-    onRevertGasLimit: numericStringSchema.default("200000"),
-    privateKey: evmPrivateKeySchema.optional(),
-    receiver: evmAddressSchema,
-    revertAddress: evmAddressSchema.optional(),
-    revertMessage: z.string().default(""),
-    rpc: z.string().url().optional(),
+const depositAndCallOptionsSchema = baseEvmDepositOptionsSchema
+  .extend({
     types: validJsonStringSchema,
     values: z.array(z.string()).min(1, "At least one value is required"),
-    yes: z.boolean().default(false),
   })
-  .refine((data) => !(data.privateKey && data.name !== DEFAULT_ACCOUNT_NAME), {
-    message: "Only one of --name or --private-key should be provided",
-    path: ["name", "privateKey"],
-  });
+  .refine(namePkRefineRule);
 
 type DepositAndCallOptions = z.infer<typeof depositAndCallOptionsSchema>;
 
 const main = async (options: DepositAndCallOptions) => {
   try {
-    const chainId = parseInt(options.chainId);
-    const networkType = options.network;
-    const rpcUrl = options.rpc || getRpcUrl(chainId);
-    const provider = new ethers.JsonRpcProvider(rpcUrl);
-
-    const privateKey =
-      options.privateKey ||
-      getAccountData<EVMAccountData>("evm", options.name)?.privateKey;
-
-    if (!privateKey) {
-      const errorMessage = handleError({
-        context: "Failed to retrieve private key",
-        error: new Error("Private key not found"),
-        shouldThrow: false,
-      });
-
-      throw new Error(errorMessage);
-    }
-
-    const { success: isPrivateKeyValid, data: parsedPrivateKey } =
-      evmPrivateKeySchema.safeParse(privateKey);
-
-    if (!isPrivateKeyValid) {
-      const errorMessage = handleError({
-        context: "Invalid private key",
-        error: new Error("Private key is invalid"),
-        shouldThrow: false,
-      });
-
-      throw new Error(errorMessage);
-    }
-
-    let signer: ethers.Wallet;
-    try {
-      signer = new ethers.Wallet(parsedPrivateKey, provider);
-    } catch (error) {
-      const errorMessage = handleError({
-        context: "Failed to create signer from private key",
-        error,
-        shouldThrow: false,
-      });
-
-      throw new Error(errorMessage);
-    }
-
-    const client = new ZetaChainClient({ network: networkType, signer });
-
-    const { hasEnoughBalance, balance, decimals } =
-      await hasSufficientBalanceEvm(
-        provider,
-        signer,
-        options.amount,
-        options.erc20
-      );
-
-    if (!hasEnoughBalance) {
-      handleError({
-        context: "Insufficient balance",
-        error: new Error(
-          `Required: ${options.amount}, Available: ${ethers.formatUnits(
-            balance,
-            decimals
-          )}`
-        ),
-        shouldThrow: true,
-      });
-    }
-
-    await printEvmTransactionDetails(signer, chainId, {
-      amount: options.amount,
-      callOnRevert: options.callOnRevert,
-      erc20: options.erc20,
-      onRevertGasLimit: options.onRevertGasLimit,
-      receiver: options.receiver,
-      revertMessage: options.revertMessage,
-    });
+    const { client, signer } = await setupTransaction(options);
 
     console.log(`Contract call details:
 Function parameters: ${options.values.join(", ")}
 Parameter types: ${options.types}
 `);
 
-    if (options.yes) {
-      console.log("Proceeding with transaction (--yes flag set)");
-    } else {
-      let confirmed;
-      try {
-        confirmed = await confirm({
-          default: true,
-          message: "Proceed with the transaction?",
-        });
-      } catch (error) {
-        console.log("\nTransaction cancelled");
-        process.exit(0);
-      }
-
-      if (!confirmed) {
-        console.log("\nTransaction cancelled");
-        process.exit(0);
-      }
-    }
+    await confirmTransaction(options);
 
     const values = parseAbiValues(options.types, options.values);
     const parsedTypes = parseJson(options.types, stringArraySchema);
@@ -162,17 +46,8 @@ Parameter types: ${options.types}
       erc20: options.erc20,
       gatewayEvm: options.gateway,
       receiver: options.receiver,
-      revertOptions: {
-        abortAddress: options.abortAddress,
-        callOnRevert: options.callOnRevert,
-        onRevertGasLimit: options.onRevertGasLimit,
-        revertAddress: options.revertAddress || signer.address,
-        revertMessage: options.revertMessage,
-      },
-      txOptions: {
-        gasLimit: options.gasLimit,
-        gasPrice: options.gasPrice,
-      },
+      revertOptions: prepareRevertOptions(options, signer),
+      txOptions: prepareTxOptions(options),
       types: parsedTypes,
       values,
     });
@@ -187,21 +62,13 @@ Parameter types: ${options.types}
   }
 };
 
-export const depositAndCallCommand = new Command("deposit-and-call")
-  .description(
-    "Deposit tokens and call a contract on ZetaChain from an EVM-compatible chain"
-  )
-  .requiredOption("--amount <amount>", "Amount of tokens to deposit")
-  .addOption(
-    new Option("--network <network>", "Network to use")
-      .choices(["mainnet", "testnet"])
-      .default("testnet")
-  )
-  .requiredOption("--chain-id <chainId>", "Chain ID of the network")
-  .requiredOption(
-    "--receiver <address>",
-    "Contract address on ZetaChain to call"
-  )
+export const depositAndCallCommand = new Command(
+  "deposit-and-call"
+).description(
+  "Deposit tokens and call a contract on ZetaChain from an EVM-compatible chain"
+);
+
+addCommonEvmDepositCommandOptions(depositAndCallCommand)
   .requiredOption(
     "--types <types>",
     'JSON string array of parameter types (e.g. \'["uint256","address"]\')'
@@ -210,46 +77,6 @@ export const depositAndCallCommand = new Command("deposit-and-call")
     "--values <values...>",
     "Parameter values for the function call"
   )
-  .addOption(
-    new Option("--name <name>", "Account name")
-      .default(DEFAULT_ACCOUNT_NAME)
-      .conflicts(["private-key"])
-  )
-  .addOption(
-    new Option(
-      "--private-key <key>",
-      "Private key for signing transactions"
-    ).conflicts(["name"])
-  )
-  .option("--rpc <url>", "RPC URL for the source chain")
-  .option(
-    "--erc20 <address>",
-    "ERC20 token address (optional for native token deposits)"
-  )
-  .option("--gateway <address>", "EVM Gateway address")
-  .option(
-    "--revert-address <address>",
-    "Address to revert to in case of failure (default: signer address)"
-  )
-  .option(
-    "--abort-address <address>",
-    `Address to receive funds if aborted (default: ${ZeroAddress})`,
-    ZeroAddress
-  )
-  .option(
-    "--call-on-revert",
-    "Whether to call revert address on failure",
-    false
-  )
-  .option(
-    "--on-revert-gas-limit <limit>",
-    "Gas limit for revert operation",
-    "200000"
-  )
-  .option("--revert-message <message>", "Message to include in revert", "")
-  .option("--gas-limit <limit>", "Gas limit for the transaction")
-  .option("--gas-price <price>", "Gas price for the transaction")
-  .option("--yes", "Skip confirmation prompt", false)
   .action(async (options) => {
     const validatedOptions = depositAndCallOptionsSchema.parse(options);
     await main(validatedOptions);

--- a/packages/commands/src/evm/depositAndCall.ts
+++ b/packages/commands/src/evm/depositAndCall.ts
@@ -7,8 +7,6 @@ import {
   typesAndValuesLengthRefineRule,
 } from "../../../../types/shared.schema";
 import { handleError } from "../../../../utils";
-import { parseAbiValues } from "../../../../utils/parseAbiValues";
-import { parseJson } from "../../../../utils/parseJson";
 import {
   addCommonEvmDepositCommandOptions,
   baseEvmDepositOptionsSchema,
@@ -16,7 +14,9 @@ import {
   prepareRevertOptions,
   prepareTxOptions,
   setupTransaction,
-} from "./common";
+} from "../../../../utils/evm.command.helpers";
+import { parseAbiValues } from "../../../../utils/parseAbiValues";
+import { parseJson } from "../../../../utils/parseJson";
 
 const depositAndCallOptionsSchema = baseEvmDepositOptionsSchema
   .extend({

--- a/packages/commands/src/evm/index.ts
+++ b/packages/commands/src/evm/index.ts
@@ -1,8 +1,10 @@
 import { Command } from "commander";
 
 import { depositCommand } from "./deposit";
+import { depositAndCallCommand } from "./depositAndCall";
 
 export const evmCommand = new Command("evm")
   .description("EVM commands")
   .addCommand(depositCommand)
+  .addCommand(depositAndCallCommand)
   .helpCommand(false);

--- a/types/shared.schema.ts
+++ b/types/shared.schema.ts
@@ -1,6 +1,8 @@
 import { ethers } from "ethers";
 import { z } from "zod";
 
+import { DEFAULT_ACCOUNT_NAME } from "./shared.constants";
+
 export const evmAddressSchema = z
   .string()
   .refine((val) => ethers.isAddress(val), "Must be a valid EVM address");
@@ -53,3 +55,13 @@ export const evmPrivateKeySchema = z
     },
     { message: "Invalid private key (must be in secp256k1 range)" }
   );
+/**
+ * Validation rule for Zod schema refinement that ensures only one of name or privateKey is provided.
+ * This prevents users from specifying both a named account and a private key at the same time.
+ */
+export const namePkRefineRule = (data: {
+  name: string;
+  privateKey?: string;
+}) => {
+  return !(data.privateKey && data.name !== DEFAULT_ACCOUNT_NAME);
+};

--- a/utils/chains.ts
+++ b/utils/chains.ts
@@ -35,3 +35,18 @@ export const getRpcUrl = (chainId: number): string => {
 
   return evmRpc.url;
 };
+
+export const getNetworkTypeByChainId = (
+  chainId: number
+): "mainnet" | "testnet" => {
+  const typedNetworks = networks as NetworksSchema;
+  const network = Object.values(typedNetworks).find(
+    (n) => n.chain_id === chainId
+  );
+
+  if (!network?.type) {
+    throw new Error(`Network with chain ID ${chainId} not found`);
+  }
+
+  return network.type as "mainnet" | "testnet";
+};

--- a/utils/chains.ts
+++ b/utils/chains.ts
@@ -48,5 +48,6 @@ export const getNetworkTypeByChainId = (
     throw new Error(`Network with chain ID ${chainId} not found`);
   }
 
-  return network.type as "mainnet" | "testnet";
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return network.type;
 };

--- a/utils/evm.command.helpers.ts
+++ b/utils/evm.command.helpers.ts
@@ -3,19 +3,20 @@ import { Command, Option } from "commander";
 import { ethers, ZeroAddress } from "ethers";
 import { z } from "zod";
 
-import { EVMAccountData } from "../../../../types/accounts.types";
-import { DEFAULT_ACCOUNT_NAME } from "../../../../types/shared.constants";
+import { ZetaChainClient } from "../packages/client/src/client";
+import { EVMAccountData } from "../types/accounts.types";
+import { DEFAULT_ACCOUNT_NAME } from "../types/shared.constants";
 import {
   evmAddressSchema,
   evmPrivateKeySchema,
   numericStringSchema,
   validAmountSchema,
-} from "../../../../types/shared.schema";
-import { handleError, printEvmTransactionDetails } from "../../../../utils";
-import { getAccountData } from "../../../../utils/accounts";
-import { hasSufficientBalanceEvm } from "../../../../utils/balances";
-import { getNetworkTypeByChainId, getRpcUrl } from "../../../../utils/chains";
-import { ZetaChainClient } from "../../../client/src/client";
+} from "../types/shared.schema";
+import { getAccountData } from "./accounts";
+import { hasSufficientBalanceEvm } from "./balances";
+import { getNetworkTypeByChainId, getRpcUrl } from "./chains";
+import { printEvmTransactionDetails } from "./formatting";
+import { handleError } from "./handleError";
 
 export const baseEvmDepositOptionsSchema = z.object({
   abortAddress: evmAddressSchema,

--- a/utils/evm.command.helpers.ts
+++ b/utils/evm.command.helpers.ts
@@ -132,18 +132,21 @@ export const confirmTransaction = async (options: EvmDepositOptions) => {
     });
   } catch (error) {
     handleError({
-      context: "Transaction cancelled",
+      context: "Failed to confirm transaction",
       error,
-      shouldThrow: true,
+      shouldThrow: false,
     });
+
+    return false; // treat as “not confirmed”
   }
 
   if (!confirmed) {
     handleError({
-      context: "Transaction cancelled",
       error: new Error("Transaction cancelled"),
-      shouldThrow: true,
+      shouldThrow: false,
     });
+
+    return false; // treat as “not confirmed”
   }
 
   return confirmed;

--- a/utils/evm.command.helpers.ts
+++ b/utils/evm.command.helpers.ts
@@ -44,6 +44,15 @@ export const setupTransaction = async (options: EvmDepositOptions) => {
   const chainId = parseInt(options.chainId);
   const networkType = getNetworkTypeByChainId(chainId);
   const rpcUrl = options.rpc || getRpcUrl(chainId);
+
+  if (!rpcUrl) {
+    handleError({
+      context: "Failed to retrieve RPC URL",
+      error: new Error("RPC URL not found"),
+      shouldThrow: true,
+    });
+  }
+
   const provider = new ethers.JsonRpcProvider(rpcUrl);
 
   const privateKey =

--- a/utils/evm.command.helpers.ts
+++ b/utils/evm.command.helpers.ts
@@ -131,13 +131,19 @@ export const confirmTransaction = async (options: EvmDepositOptions) => {
       message: "Proceed with the transaction?",
     });
   } catch (error) {
-    console.log("\nTransaction cancelled");
-    process.exit(0);
+    handleError({
+      context: "Transaction cancelled",
+      error,
+      shouldThrow: true,
+    });
   }
 
   if (!confirmed) {
-    console.log("\nTransaction cancelled");
-    process.exit(0);
+    handleError({
+      context: "Transaction cancelled",
+      error: new Error("Transaction cancelled"),
+      shouldThrow: true,
+    });
   }
 
   return confirmed;


### PR DESCRIPTION
```bash
yarn zetachain evm deposit-and-call \
    --receiver 0xc15725fD586489A23E1D52d43301918420Fb964c \
    --amount 0.001 \
    --chain-id 84532 \
    --gateway 0x0c487a766110c85d301d96e33579c5b317fa4995 \
    --types address bytes bool \
    --values 0x777915D031d1e8144c90D025C594b3b8Bf07a08d 0xB2F0f114195f45D0530fe52841e420671f52096D false \
    --name alice \
    --yes
```

<img width="1491" alt="image" src="https://github.com/user-attachments/assets/a396c6bc-5507-4fc3-95d2-9715f6e5d402" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new CLI command to deposit tokens and invoke contract calls on ZetaChain from EVM-compatible chains.
  - Added enhanced validation and user confirmation for EVM deposit commands.
  - Improved error handling and transaction setup for deposit-related commands.
- **Refactor**
  - Streamlined the EVM deposit command for better modularity and reduced code duplication.
  - Added the new `deposit-and-call` subcommand to the EVM command group.
- **Chores**
  - Added utility functions and schemas to support reusable CLI option handling and validation for EVM transactions.
  - Added network type detection by chain ID.
  - Enforced validation rules to prevent conflicting account and private key inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->