### PR TITLE
feat: evm call command

### DIFF
--- a/packages/commands/src/evm/call.ts
+++ b/packages/commands/src/evm/call.ts
@@ -20,7 +20,6 @@ import {
   setupTransaction,
 } from "../../../../utils/evm.command.helpers";
 import { parseAbiValues } from "../../../../utils/parseAbiValues";
-import { parseJson } from "../../../../utils/parseJson";
 
 const callOptionsSchema = baseEvmOptionsSchema
   .extend({
@@ -40,7 +39,6 @@ const main = async (options: CallOptions) => {
     const { client, signer, chainId } = setupTransaction(options);
 
     await printEvmTransactionDetails(signer, chainId, {
-      amount: "",
       callOnRevert: options.callOnRevert,
       onRevertGasLimit: options.onRevertGasLimit,
       receiver: options.receiver,
@@ -59,14 +57,13 @@ Parameter types: ${stringifiedTypes}
     if (!isConfirmed) return;
 
     const values = parseAbiValues(stringifiedTypes, options.values);
-    const parsedTypes = parseJson(stringifiedTypes, stringArraySchema);
 
     const tx = await client.evmCall({
       gatewayEvm: options.gateway,
       receiver: options.receiver,
       revertOptions: prepareRevertOptions(options, signer),
       txOptions: prepareTxOptions(options),
-      types: parsedTypes,
+      types: options.types,
       values,
     });
     console.log("Transaction hash:", tx.hash);

--- a/packages/commands/src/evm/depositAndCall.ts
+++ b/packages/commands/src/evm/depositAndCall.ts
@@ -23,7 +23,6 @@ import {
   setupTransaction,
 } from "../../../../utils/evm.command.helpers";
 import { parseAbiValues } from "../../../../utils/parseAbiValues";
-import { parseJson } from "../../../../utils/parseJson";
 
 const depositAndCallOptionsSchema = baseEvmOptionsSchema
   .extend({
@@ -72,7 +71,6 @@ Parameter types: ${stringifiedTypes}
     if (!isConfirmed) return;
 
     const values = parseAbiValues(stringifiedTypes, options.values);
-    const parsedTypes = parseJson(stringifiedTypes, stringArraySchema);
 
     const tx = await client.evmDepositAndCall({
       amount: options.amount,
@@ -81,7 +79,7 @@ Parameter types: ${stringifiedTypes}
       receiver: options.receiver,
       revertOptions: prepareRevertOptions(options, signer),
       txOptions: prepareTxOptions(options),
-      types: parsedTypes,
+      types: options.types,
       values,
     });
     console.log("Transaction hash:", tx.hash);

--- a/packages/commands/src/evm/index.ts
+++ b/packages/commands/src/evm/index.ts
@@ -1,10 +1,12 @@
 import { Command } from "commander";
 
+import { callCommand } from "./call";
 import { depositCommand } from "./deposit";
 import { depositAndCallCommand } from "./depositAndCall";
 
 export const evmCommand = new Command("evm")
   .description("EVM commands")
-  .addCommand(depositCommand)
+  .addCommand(callCommand)
   .addCommand(depositAndCallCommand)
+  .addCommand(depositCommand)
   .helpCommand(false);

--- a/utils/formatting.ts
+++ b/utils/formatting.ts
@@ -105,7 +105,7 @@ export const printEvmTransactionDetails = async (
   signer: ethers.Wallet,
   chainId: number,
   options: {
-    amount: string;
+    amount?: string;
     callOnRevert: boolean;
     erc20?: string;
     onRevertGasLimit: string;
@@ -134,9 +134,12 @@ export const printEvmTransactionDetails = async (
 
   console.log(`
 From:   ${signer.address} on ${getChainName(chainId)}
-To:     ${options.receiver} on ZetaChain
-Amount: ${options.amount} ${tokenSymbol}${
-    !options.callOnRevert ? `\nRefund: ${signer.address}` : ""
+To:     ${options.receiver} on ZetaChain${
+    options.amount
+      ? `\nAmount: ${options.amount} ${tokenSymbol}${
+          !options.callOnRevert ? `\nRefund: ${signer.address}` : ""
+        }`
+      : ""
   }
 Call on revert: ${options.callOnRevert ? "true" : "false"}${
     options.callOnRevert


### PR DESCRIPTION
closes: #245 

```bash
yarn zetachain evm call \
    --receiver 0xc15725fD586489A23E1D52d43301918420Fb964c \
    --chain-id 84532 \
    --gateway 0x0c487a766110c85d301d96e33579c5b317fa4995 \
    --types string \
    --values "Alice" \
    --name alice \
    --yes
```

<img width="1498" alt="image" src="https://github.com/user-attachments/assets/4407139e-17ce-4057-b0a5-13750668cc22" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new CLI command for contract calls on ZetaChain from EVM-compatible chains.
- **Enhancements**
  - Improved deposit and deposit-and-call commands with explicit amount and ERC20 token handling, enhanced validation, and balance checks.
  - Transaction details now conditionally display amount and refund information.
  - Refined user prompts and transaction confirmation steps.
- **Refactor**
  - Modularized and simplified command option handling and transaction setup for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->