### PR TITLE
feat: fetch Sui balances and correctly import `suiprivkey1` keys

### DIFF
--- a/packages/client/src/getBalances.ts
+++ b/packages/client/src/getBalances.ts
@@ -1,4 +1,5 @@
 import { TokenBalance } from "../../../types/balances.types";
+import { ObserverSupportedChain } from "../../../types/supportedChains.types";
 import {
   addZetaTokens,
   collectTokensFromForeignCoins,
@@ -13,7 +14,6 @@ import {
   prepareMulticallContexts,
 } from "../../../utils/balances";
 import { ZetaChainClient } from "./client";
-import { ObserverSupportedChain } from "../../../types/supportedChains.types";
 
 /**
  * Get token balances of all tokens on all chains connected to ZetaChain.

--- a/packages/client/src/getBalances.ts
+++ b/packages/client/src/getBalances.ts
@@ -136,11 +136,7 @@ export const getBalances = async function (
 
   // Get Sui balances
   if (suiAddress) {
-    const suiBalances = await getSuiBalances(
-      allTokens,
-      suiAddress,
-      this.getEndpoint.bind(this)
-    );
+    const suiBalances = await getSuiBalances(allTokens, suiAddress);
     balances.push(...suiBalances);
   }
 

--- a/packages/client/src/getBalances.ts
+++ b/packages/client/src/getBalances.ts
@@ -9,9 +9,11 @@ import {
   getNativeEvmTokenBalances,
   getSolanaBalances,
   getSplTokenBalances,
+  getSuiBalances,
   prepareMulticallContexts,
 } from "../../../utils/balances";
 import { ZetaChainClient } from "./client";
+import { ObserverSupportedChain } from "../../../types/supportedChains.types";
 
 /**
  * Get token balances of all tokens on all chains connected to ZetaChain.
@@ -20,6 +22,7 @@ import { ZetaChainClient } from "./client";
  * @param options.evmAddress EVM address
  * @param options.btcAddress Bitcoin address
  * @param options.solanaAddress Solana address
+ * @param options.suiAddress Sui address
  * @returns Array of token balances
  */
 export const getBalances = async function (
@@ -28,105 +31,117 @@ export const getBalances = async function (
     evmAddress,
     btcAddress,
     solanaAddress,
-  }: { btcAddress?: string; evmAddress?: string; solanaAddress?: string }
+    suiAddress,
+  }: {
+    btcAddress?: string;
+    evmAddress?: string;
+    solanaAddress?: string;
+    suiAddress?: string;
+  }
 ): Promise<TokenBalance[]> {
-  // Helper functions to preserve 'this' context when passed as callbacks
-  // These ensure methods maintain the correct client context when used in other functions
-  const getEndpoint = (type: string, chainName: string): string =>
-    this.getEndpoint(type, chainName);
-
-  const getChains = () => this.getChains();
-  const getChainId = (name: string) => this.getChainId(name);
-
-  // Step 1: Gather data
-  const zetaChainId = getChainId(`zeta_${this.network}`);
-  const supportedChains = await this.getSupportedChains();
   const foreignCoins = await this.getForeignCoins();
+  const supportedChains = await this.getSupportedChains();
+  const zetaChainId = this.getChainId(`zeta_${this.network}`);
+  if (!zetaChainId) {
+    throw new Error("Failed to get ZetaChain ID");
+  }
+  const chainIdString = zetaChainId.toString();
 
-  // Step 2: Collect and prepare tokens
-  // Handle potential null values for zetaChainId
-  const chainIdString =
-    typeof zetaChainId === "number"
-      ? zetaChainId.toString()
-      : zetaChainId || "";
-
-  // Collect and prepare all tokens in a single step
-  const tokens = enrichTokens(
-    [
-      ...collectTokensFromForeignCoins(
-        foreignCoins,
-        supportedChains,
-        chainIdString
-      ),
-      ...addZetaTokens(supportedChains, getChains(), chainIdString),
-    ],
-    supportedChains
+  const tokens = collectTokensFromForeignCoins(
+    foreignCoins,
+    supportedChains,
+    chainIdString
   );
+  const zetaTokens = addZetaTokens(supportedChains, this.chains, chainIdString);
+  const allTokens = enrichTokens([...tokens, ...zetaTokens], supportedChains);
 
-  // Initialize the array of balances that we'll build up
-  let balances: TokenBalance[] = [];
+  const balances: TokenBalance[] = [];
 
-  // Step 3: Get EVM token balances
+  // Get EVM token balances
   if (evmAddress) {
-    const multicallContexts = prepareMulticallContexts(tokens, evmAddress);
+    const evmTokens = allTokens.filter(
+      (token) =>
+        token.chain_name &&
+        supportedChains.find(
+          (chain: ObserverSupportedChain) => chain.name === token.chain_name
+        )?.vm === "evm"
+    );
 
-    // Process each chain with multicall, falling back to individual calls if needed
-    for (const chainName of Object.keys(multicallContexts)) {
-      const rpc = getEndpoint("evm", chainName);
-      const multicallResults = await getEvmTokenBalancesWithMulticall(
-        chainName,
-        rpc,
-        multicallContexts[chainName],
-        tokens
+    const multicallContexts = prepareMulticallContexts(evmTokens, evmAddress);
+
+    for (const [chainName, contexts] of Object.entries(multicallContexts)) {
+      const chain = supportedChains.find(
+        (c: ObserverSupportedChain) => c.name === chainName
       );
+      if (!chain) continue;
 
-      if (multicallResults.length > 0) {
-        balances = balances.concat(multicallResults);
-      } else {
-        // Fallback to individual calls if multicall fails
-        const individualResults = await getEvmTokenBalancesFallback(
+      const rpc = this.getEndpoint("evm", chain.name);
+      let chainBalances: TokenBalance[];
+
+      try {
+        chainBalances = await getEvmTokenBalancesWithMulticall(
           chainName,
           rpc,
-          tokens,
+          contexts,
+          evmTokens
+        );
+      } catch (error) {
+        console.error(
+          `Multicall failed for ${chainName}, falling back to individual calls:`,
+          error
+        );
+        chainBalances = await getEvmTokenBalancesFallback(
+          chainName,
+          rpc,
+          evmTokens,
           evmAddress
         );
-        balances = balances.concat(individualResults);
       }
+
+      balances.push(...chainBalances);
     }
 
     // Get native EVM token balances
     const nativeBalances = await getNativeEvmTokenBalances(
-      tokens,
+      allTokens,
       evmAddress,
-      getEndpoint,
-      getChains()
+      this.getEndpoint.bind(this),
+      this.chains
     );
-    balances = balances.concat(nativeBalances);
+    balances.push(...nativeBalances);
   }
 
-  // Step 4: Get BTC balances
+  // Get Bitcoin balances
   if (btcAddress) {
-    const btcBalances = await getBtcBalances(tokens, btcAddress);
-    balances = balances.concat(btcBalances);
+    const btcBalances = await getBtcBalances(allTokens, btcAddress);
+    balances.push(...btcBalances);
   }
 
-  // Step 5: Get Solana balances
+  // Get Solana balances
   if (solanaAddress) {
-    // Get native SOL balances
-    const solBalances = await getSolanaBalances(
-      tokens,
+    const solanaBalances = await getSolanaBalances(
+      allTokens,
       solanaAddress,
-      getEndpoint
+      this.getEndpoint.bind(this)
     );
-    balances = balances.concat(solBalances);
+    balances.push(...solanaBalances);
 
-    // Get SPL token balances
     const splBalances = await getSplTokenBalances(
-      tokens,
+      allTokens,
       solanaAddress,
-      getEndpoint
+      this.getEndpoint.bind(this)
     );
-    balances = balances.concat(splBalances);
+    balances.push(...splBalances);
+  }
+
+  // Get Sui balances
+  if (suiAddress) {
+    const suiBalances = await getSuiBalances(
+      allTokens,
+      suiAddress,
+      this.getEndpoint.bind(this)
+    );
+    balances.push(...suiBalances);
   }
 
   return balances;

--- a/packages/commands/src/query/balances.ts
+++ b/packages/commands/src/query/balances.ts
@@ -82,13 +82,13 @@ const main = async (options: BalancesOptions) => {
 
     const suiAddress = resolveSuiAddress({
       accountName: options.name,
-      suiAddress: options.sui,
       handleError: () =>
         spinner.warn(
           `Error resolving Sui address ${
             !options.sui && options.name ? `for user '${options.name}'` : ""
           }`
         ),
+      suiAddress: options.sui,
     });
 
     if (!evmAddress && !btcAddress && !solanaAddress && !suiAddress) {

--- a/types/balances.types.ts
+++ b/types/balances.types.ts
@@ -84,3 +84,10 @@ type AggregateResult = [blockNumber: bigint, returnData: string[]];
 export interface MulticallContract extends OmitIndexSignature<Contract> {
   aggregate?: ContractMethod<[calls: Call[]], AggregateResult, AggregateResult>;
 }
+
+export interface GetBalancesOptions {
+  btcAddress?: string;
+  evmAddress?: string;
+  solanaAddress?: string;
+  suiAddress?: string;
+}

--- a/utils/accounts.ts
+++ b/utils/accounts.ts
@@ -1,8 +1,8 @@
 import confirm from "@inquirer/confirm";
+import { decodeSuiPrivateKey } from "@mysten/sui/cryptography";
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 import { Secp256k1Keypair } from "@mysten/sui/keypairs/secp256k1";
 import { Secp256r1Keypair } from "@mysten/sui/keypairs/secp256r1";
-import { decodeSuiPrivateKey } from "@mysten/sui/cryptography";
 import { Keypair } from "@solana/web3.js";
 import * as bitcoin from "bitcoinjs-lib";
 import ECPairFactory from "ecpair";

--- a/utils/addressResolver.ts
+++ b/utils/addressResolver.ts
@@ -63,12 +63,8 @@ const isValidBitcoinAddress = (
  */
 const isValidSuiAddress = (address?: string): boolean => {
   if (!address) return false;
-  try {
-    // Sui addresses are 32 bytes (64 hex chars) prefixed with 0x
-    return /^0x[a-fA-F0-9]{64}$/.test(address);
-  } catch {
-    return false;
-  }
+  // Sui addresses are 1-64 hex chars prefixed with 0x
+  return /^0x[a-fA-F0-9]{1,64}$/.test(address);
 };
 
 /**

--- a/utils/addressResolver.ts
+++ b/utils/addressResolver.ts
@@ -1,7 +1,6 @@
 import { PublicKey } from "@solana/web3.js";
 import * as bitcoin from "bitcoinjs-lib";
 import { ethers } from "ethers";
-import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 
 import {
   BitcoinAccountData,
@@ -202,10 +201,10 @@ export const resolveBitcoinAddress = ({
 export interface ResolveSuiAddressArgs {
   /** Account name to use if address not provided */
   accountName?: string;
-  /** A Sui address to validate */
-  suiAddress?: string;
   /** Function to handle errors */
   handleError?: () => void;
+  /** A Sui address to validate */
+  suiAddress?: string;
 }
 
 /**

--- a/utils/balances.ts
+++ b/utils/balances.ts
@@ -96,6 +96,16 @@ export const collectTokensFromForeignCoins = (
           zrc20: foreignCoin.zrc20_contract_address,
         };
         return [svmToken, zrc20Token];
+      } else if (supportedChain?.vm === "mvm_sui") {
+        const svmToken: Token = {
+          chain_id: foreignCoin.foreign_chain_id,
+          coin_type: "SUI",
+          contract: foreignCoin.asset,
+          decimals: foreignCoin.decimals,
+          symbol: foreignCoin.symbol,
+          zrc20: foreignCoin.zrc20_contract_address,
+        };
+        return [svmToken, zrc20Token];
       }
 
       // If no matching chain type, just return the ZRC20 token
@@ -536,10 +546,7 @@ export const getSuiBalances = async (
   const suiChainNames = ["sui_mainnet", "sui_testnet"];
 
   const suiTokens = tokens.filter(
-    (token) =>
-      token.coin_type === "Gas" &&
-      token.chain_name &&
-      suiChainNames.includes(token.chain_name)
+    (token) => token.chain_name && suiChainNames.includes(token.chain_name)
   );
 
   // Use Promise.all with map for parallel processing

--- a/utils/balances.ts
+++ b/utils/balances.ts
@@ -531,10 +531,9 @@ export const getSolanaBalances = async (
  */
 export const getSuiBalances = async (
   tokens: Token[],
-  suiAddress: string,
-  getEndpoint: (type: string, chainName: string) => string
+  suiAddress: string
 ): Promise<TokenBalance[]> => {
-  const suiChainNames = ["sui_mainnet", "sui_testnet", "sui_devnet"];
+  const suiChainNames = ["sui_mainnet", "sui_testnet"];
 
   const suiTokens = tokens.filter(
     (token) =>
@@ -548,10 +547,8 @@ export const getSuiBalances = async (
     suiTokens.map(async (token) => {
       try {
         const network =
-          (token.chain_name?.replace("sui_", "") as
-            | "mainnet"
-            | "testnet"
-            | "devnet") || "testnet";
+          (token.chain_name?.replace("sui_", "") as "mainnet" | "testnet") ||
+          "testnet";
         const client = new SuiClient({ url: getFullnodeUrl(network) });
 
         const coins = await client.getCoins({

--- a/utils/balances.ts
+++ b/utils/balances.ts
@@ -568,8 +568,7 @@ export const getSuiBalances = async (
             totalBalance += BigInt(coin.balance);
           }
 
-          // Convert from MIST (10^9) to SUI
-          const balance = (Number(totalBalance) / 10 ** 9).toFixed(9);
+          const balance = ethers.formatUnits(totalBalance, 9);
 
           return {
             ...token,
@@ -588,11 +587,7 @@ export const getSuiBalances = async (
             totalBalance += BigInt(coin.balance);
           }
 
-          // Convert using token's decimals
-          const balance = (
-            Number(totalBalance) /
-            10 ** (token.decimals || 9)
-          ).toFixed(9);
+          const balance = ethers.formatUnits(totalBalance, token.decimals);
 
           return {
             ...token,

--- a/utils/balances.ts
+++ b/utils/balances.ts
@@ -1,9 +1,9 @@
+import { getFullnodeUrl, SuiClient } from "@mysten/sui/client";
 import ERC20_ABI from "@openzeppelin/contracts/build/contracts/ERC20.json";
 import { getAddress, ParamChainName } from "@zetachain/protocol-contracts";
 import ZRC20 from "@zetachain/protocol-contracts/abi/ZRC20.sol/ZRC20.json";
 import axios from "axios";
 import { AbiCoder, ethers } from "ethers";
-import { getFullnodeUrl, SuiClient } from "@mysten/sui/client";
 
 import {
   Call,
@@ -552,8 +552,8 @@ export const getSuiBalances = async (
         const client = new SuiClient({ url: getFullnodeUrl(network) });
 
         const coins = await client.getCoins({
-          owner: suiAddress,
           coinType: "0x2::sui::SUI",
+          owner: suiAddress,
         });
 
         let totalBalance = BigInt(0);

--- a/utils/balances.ts
+++ b/utils/balances.ts
@@ -537,7 +537,7 @@ export const getSolanaBalances = async (
 };
 
 /**
- * Gets Sui native SUI balances
+ * Gets Sui native SUI and fungible token balances
  */
 export const getSuiBalances = async (
   tokens: Token[],
@@ -549,7 +549,6 @@ export const getSuiBalances = async (
     (token) => token.chain_name && suiChainNames.includes(token.chain_name)
   );
 
-  // Use Promise.all with map for parallel processing
   const balanceResults = await Promise.all(
     suiTokens.map(async (token) => {
       try {
@@ -558,7 +557,6 @@ export const getSuiBalances = async (
           "testnet";
         const client = new SuiClient({ url: getFullnodeUrl(network) });
 
-        // For native SUI
         if (token.coin_type === "Gas") {
           const coins = await client.getCoins({
             owner: suiAddress,

--- a/utils/balances.ts
+++ b/utils/balances.ts
@@ -559,8 +559,8 @@ export const getSuiBalances = async (
 
         if (token.coin_type === "Gas") {
           const coins = await client.getCoins({
-            owner: suiAddress,
             coinType: "0x2::sui::SUI",
+            owner: suiAddress,
           });
 
           let totalBalance = BigInt(0);
@@ -579,8 +579,8 @@ export const getSuiBalances = async (
         } else if (token.coin_type === "SUI" && token.contract) {
           const coinType = `0x${token.contract}`;
           const coins = await client.getCoins({
-            owner: suiAddress,
             coinType,
+            owner: suiAddress,
           });
 
           let totalBalance = BigInt(0);

--- a/utils/formatting.ts
+++ b/utils/formatting.ts
@@ -41,6 +41,7 @@ export interface FormatAddressesOptions {
   bitcoin?: string;
   evm?: string;
   solana?: string;
+  sui?: string;
 }
 
 export const formatAddresses = (options: FormatAddressesOptions): string => {
@@ -59,6 +60,11 @@ export const formatAddresses = (options: FormatAddressesOptions): string => {
   if (options.solana) {
     const solanaStr = `Solana: \x1b[35m${options.solana}\x1b[0m`;
     parts.push(solanaStr);
+  }
+
+  if (options.sui) {
+    const suiStr = `Sui: \x1b[32m${options.sui}\x1b[0m`;
+    parts.push(suiStr);
   }
 
   return parts.join("\n");


### PR DESCRIPTION
```
yarn zetachain accounts import --type sui --private-key suiprivkey1...
```

```
yarn zetachain query balances                                                                          

⚠ Error resolving EVM address 
⚠ Error resolving Solana address 
⚠ Error resolving Bitcoin testnet address
✔ Successfully fetched balances

Sui: 0x71973ec13be525f912b1bcda5d631f10388cb13cd2202b7b8650d4d6fe4b2339

┌─────────┬─────────────┬───────────────┬────────────┬───────┐
│ (index) │ Amount      │ Chain         │ Token      │ Type  │
├─────────┼─────────────┼───────────────┼────────────┼───────┤
│ 0       │ '10.000000' │ 'sui_testnet' │ 'USDC.SUI' │ 'SUI' │
│ 1       │ '1.952227'  │ 'sui_testnet' │ 'SUI.SUI'  │ 'Gas' │
└─────────┴─────────────┴───────────────┴────────────┴───────┘
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for fetching and displaying token balances for Sui blockchain addresses alongside existing EVM, Bitcoin, and Solana support.
  - Introduced command-line option to query balances for a Sui address.
  - Enhanced address formatting and resolution utilities to handle Sui addresses.
- **Improvements**
  - Expanded Sui account creation to support multiple key schemas for greater flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->