### PR TITLE
feat: Zetachain call command

### DIFF
--- a/packages/client/src/zetachainCall.ts
+++ b/packages/client/src/zetachainCall.ts
@@ -23,7 +23,7 @@ import { ZetaChainClient } from "./client";
  * @param {object} args - The function arguments.
  * @param {string} args.function - The name of the function to be executed on the target contract.
  * @param {string} args.gatewayZetaChain - The address of the ZetaChain gateway contract.
- * @param {string} args.receiver - The address of the contract or account that will receive the call.
+ * @param {string} args.receiver - The address or identifier of the contract or account that will receive the call. Can be any string - if not a hex string, it will be converted to a hex representation of its UTF-8 bytes.
  * @param {string} args.types - JSON string representing the types of the function parameters (e.g., ["uint256", "address"]).
  * @param {Array} args.values - The values to be passed to the function (should match the types).
  * @param {string} args.zrc20 - The address of the ZRC20 token contract used for paying gas fees.

--- a/packages/commands/src/evm/deposit.ts
+++ b/packages/commands/src/evm/deposit.ts
@@ -14,11 +14,11 @@ import {
 import {
   addCommonEvmCommandOptions,
   baseEvmOptionsSchema,
-  checkSufficientBalance,
-  confirmTransaction,
+  checkSufficientEvmBalance,
+  confirmEvmTransaction,
   prepareRevertOptions,
   prepareTxOptions,
-  setupTransaction,
+  setupEvmTransaction,
 } from "../../../../utils/evm.command.helpers";
 
 const depositOptionsSchema = baseEvmOptionsSchema
@@ -32,9 +32,9 @@ type DepositOptions = z.infer<typeof depositOptionsSchema>;
 
 const main = async (options: DepositOptions) => {
   try {
-    const { client, provider, signer, chainId } = setupTransaction(options);
+    const { client, provider, signer, chainId } = setupEvmTransaction(options);
 
-    await checkSufficientBalance(
+    await checkSufficientEvmBalance(
       provider,
       signer,
       options.amount,
@@ -50,7 +50,7 @@ const main = async (options: DepositOptions) => {
       revertMessage: options.revertMessage,
     });
 
-    const isConfirmed = await confirmTransaction(options);
+    const isConfirmed = await confirmEvmTransaction(options);
 
     if (!isConfirmed) return;
 

--- a/packages/commands/src/evm/depositAndCall.ts
+++ b/packages/commands/src/evm/depositAndCall.ts
@@ -16,11 +16,11 @@ import {
 import {
   addCommonEvmCommandOptions,
   baseEvmOptionsSchema,
-  checkSufficientBalance,
-  confirmTransaction,
+  checkSufficientEvmBalance,
+  confirmEvmTransaction,
   prepareRevertOptions,
   prepareTxOptions,
-  setupTransaction,
+  setupEvmTransaction,
 } from "../../../../utils/evm.command.helpers";
 import { parseAbiValues } from "../../../../utils/parseAbiValues";
 
@@ -41,9 +41,9 @@ type DepositAndCallOptions = z.infer<typeof depositAndCallOptionsSchema>;
 
 const main = async (options: DepositAndCallOptions) => {
   try {
-    const { client, provider, signer, chainId } = setupTransaction(options);
+    const { client, provider, signer, chainId } = setupEvmTransaction(options);
 
-    await checkSufficientBalance(
+    await checkSufficientEvmBalance(
       provider,
       signer,
       options.amount,
@@ -66,7 +66,7 @@ Function parameters: ${options.values.join(", ")}
 Parameter types: ${stringifiedTypes}
 `);
 
-    const isConfirmed = await confirmTransaction(options);
+    const isConfirmed = await confirmEvmTransaction(options);
 
     if (!isConfirmed) return;
 

--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -4,3 +4,4 @@ export * from "./evm";
 export * from "./query";
 export * from "./solana";
 export * from "./sui";
+export * from "./zetachain";

--- a/packages/commands/src/program.ts
+++ b/packages/commands/src/program.ts
@@ -7,6 +7,7 @@ import { evmCommand } from "./evm";
 import { queryCommand } from "./query";
 import { solanaCommand } from "./solana";
 import { suiCommand } from "./sui";
+import { zetachainCommand } from "./zetachain";
 
 export const toolkitCommand = new Command("toolkit")
   .description("Local development environment")
@@ -18,5 +19,6 @@ toolkitCommand.addCommand(evmCommand);
 toolkitCommand.addCommand(queryCommand);
 toolkitCommand.addCommand(solanaCommand);
 toolkitCommand.addCommand(suiCommand);
+toolkitCommand.addCommand(zetachainCommand);
 
 toolkitCommand.parse(process.argv);

--- a/packages/commands/src/zetachain/index.ts
+++ b/packages/commands/src/zetachain/index.ts
@@ -1,0 +1,9 @@
+import { Command } from "commander";
+
+import { callCommand } from "./call";
+
+export const zetachainCommand = new Command("zetachain")
+  .description("ZetaChain commands")
+  .alias("z")
+  .addCommand(callCommand)
+  .helpCommand(false);

--- a/test/toHexString.test.ts
+++ b/test/toHexString.test.ts
@@ -23,6 +23,13 @@ describe("toHexString", () => {
     expect(toHexString("🚀")).toBe("0xf09f9a80"); // Rocket emoji in hex
   });
 
+  it("should correctly encode Solana account addresses", () => {
+    const solanaAddr = "HzmjfpWytYAcppQkYyp611BDf6vXUUFMMhRF7ndHYCMi";
+    expect(toHexString(solanaAddr)).toBe(
+      "0x487a6d6a66705779745941637070516b5979703631314244663676585555464d4d685246376e644859434d69"
+    );
+  });
+
   it("should handle strings with spaces", () => {
     expect(toHexString("hello world")).toBe("0x68656c6c6f20776f726c64"); // "hello world" in hex
     expect(toHexString("  ")).toBe("0x2020"); // Two spaces in hex

--- a/types/shared.schema.ts
+++ b/types/shared.schema.ts
@@ -98,3 +98,22 @@ export const typesAndDataExclusivityRefineRule = {
     return true;
   },
 };
+
+export const functionTypesValuesConsistencyRule = {
+  message:
+    "If providing --function, you must also provide --types and --values (and vice versa)",
+  path: ["function"],
+  rule: (data: { function?: string; types?: string[]; values?: string[] }) => {
+    // If function is provided, both types and values must be provided
+    if (data.function && (!data.types || !data.values)) {
+      return false;
+    }
+
+    // If types or values are provided, function must be provided
+    if ((data.types || data.values) && !data.function) {
+      return false;
+    }
+
+    return true;
+  },
+};

--- a/utils/evm.command.helpers.ts
+++ b/utils/evm.command.helpers.ts
@@ -36,7 +36,7 @@ export const baseEvmOptionsSchema = z.object({
 type BaseEvmOptions = z.infer<typeof baseEvmOptionsSchema>;
 
 // Common setup function for both deposit commands
-export const setupTransaction = (options: BaseEvmOptions) => {
+export const setupEvmTransaction = (options: BaseEvmOptions) => {
   const chainId = parseInt(options.chainId);
   const networkType = getNetworkTypeByChainId(chainId);
   const rpcUrl = options.rpc || getRpcUrl(chainId);
@@ -84,7 +84,7 @@ export const setupTransaction = (options: BaseEvmOptions) => {
   return { chainId, client, provider, signer };
 };
 
-export const checkSufficientBalance = async (
+export const checkSufficientEvmBalance = async (
   provider: ethers.JsonRpcProvider,
   signer: ethers.Wallet,
   amount: string,
@@ -111,8 +111,7 @@ export const checkSufficientBalance = async (
   }
 };
 
-// Common confirmation prompt for transactions
-export const confirmTransaction = async (options: BaseEvmOptions) => {
+export const confirmEvmTransaction = async (options: BaseEvmOptions) => {
   if (options.yes) {
     console.log("Proceeding with transaction (--yes flag set)");
     return true;

--- a/utils/zetachain.command.helpers.ts
+++ b/utils/zetachain.command.helpers.ts
@@ -1,0 +1,204 @@
+import confirm from "@inquirer/confirm";
+import { Command, Option } from "commander";
+import { ethers, ZeroAddress } from "ethers";
+import { z } from "zod";
+
+import { ZetaChainClient } from "../packages/client/src/client";
+import { EVMAccountData } from "../types/accounts.types";
+import { DEFAULT_ACCOUNT_NAME } from "../types/shared.constants";
+import {
+  evmAddressSchema,
+  evmPrivateKeySchema,
+  numericStringSchema,
+} from "../types/shared.schema";
+import { getAccountData } from "./accounts";
+import { getRpcUrl } from "./chains";
+import { handleError } from "./handleError";
+
+export const baseZetachainOptionsSchema = z.object({
+  abortAddress: evmAddressSchema,
+  callOnRevert: z.boolean().default(false),
+  callOptionsGasLimit: numericStringSchema.default("7000000"),
+  callOptionsIsArbitraryCall: z.boolean().default(false),
+  gatewayZetachain: evmAddressSchema.optional(),
+  name: z.string().default(DEFAULT_ACCOUNT_NAME),
+  network: z.enum(["mainnet", "testnet"]).default("testnet"),
+  onRevertGasLimit: numericStringSchema.default("7000000"),
+  privateKey: evmPrivateKeySchema.optional(),
+  receiver: evmAddressSchema,
+  revertAddress: evmAddressSchema,
+  revertMessage: z.string().default("0x"),
+  txOptionsGasLimit: numericStringSchema.default("7000000"),
+  txOptionsGasPrice: numericStringSchema.default("10000000000"),
+  yes: z.boolean().default(false),
+  zrc20: evmAddressSchema,
+});
+
+type BaseZetachainOptions = z.infer<typeof baseZetachainOptionsSchema>;
+
+export const setupZetachainTransaction = (options: BaseZetachainOptions) => {
+  const privateKey =
+    options.privateKey ||
+    getAccountData<EVMAccountData>("evm", options.name)?.privateKey;
+
+  if (!privateKey) {
+    const errorMessage = handleError({
+      context: "Failed to retrieve private key",
+      error: new Error("Private key not found"),
+      shouldThrow: false,
+    });
+
+    throw new Error(errorMessage);
+  }
+
+  let signer: ethers.Wallet;
+
+  const rpc = getRpcUrl(options.network === "mainnet" ? 7000 : 7001);
+
+  if (!rpc) {
+    handleError({
+      context: "Failed to retrieve RPC URL",
+      error: new Error("RPC URL not found"),
+      shouldThrow: true,
+    });
+  }
+
+  const provider = new ethers.JsonRpcProvider(rpc);
+
+  try {
+    signer = new ethers.Wallet(privateKey, provider);
+  } catch (error) {
+    const errorMessage = handleError({
+      context: "Failed to create signer from private key",
+      error,
+      shouldThrow: false,
+    });
+
+    throw new Error(errorMessage);
+  }
+
+  const client = new ZetaChainClient({
+    network: options.network,
+    signer,
+  });
+
+  return { client };
+};
+
+export const confirmZetachainTransaction = async (
+  options: BaseZetachainOptions
+) => {
+  if (options.yes) {
+    console.log("Proceeding with transaction (--yes flag set)");
+    return true;
+  }
+
+  let confirmed;
+  try {
+    confirmed = await confirm({
+      default: true,
+      message: "Proceed with the transaction?",
+    });
+  } catch (error) {
+    handleError({
+      context: "Failed to confirm transaction",
+      error,
+      shouldThrow: false,
+    });
+
+    return false; // treat as "not confirmed"
+  }
+
+  if (!confirmed) {
+    handleError({
+      error: new Error("Transaction cancelled"),
+      shouldThrow: false,
+    });
+
+    return false; // treat as "not confirmed"
+  }
+
+  return confirmed;
+};
+
+// Common revert options preparation
+export const prepareRevertOptions = (options: BaseZetachainOptions) => {
+  return {
+    abortAddress: options.abortAddress,
+    callOnRevert: options.callOnRevert,
+    onRevertGasLimit: options.onRevertGasLimit,
+    revertAddress: options.revertAddress,
+    revertMessage: options.revertMessage,
+  };
+};
+
+// Common transaction options preparation
+export const prepareTxOptions = (options: BaseZetachainOptions) => {
+  return {
+    gasLimit: options.txOptionsGasLimit,
+    gasPrice: options.txOptionsGasPrice,
+  };
+};
+
+// Common call options preparation
+export const prepareCallOptions = (options: BaseZetachainOptions) => {
+  return {
+    gasLimit: options.callOptionsGasLimit,
+    isArbitraryCall: options.callOptionsIsArbitraryCall,
+  };
+};
+
+export const addCommonZetachainCommandOptions = (command: Command) => {
+  return command
+    .requiredOption("--zrc20 <address>", "The address of ZRC-20 to pay fees")
+    .requiredOption(
+      "--receiver <address>",
+      "The address of the receiver contract on a connected chain"
+    )
+    .addOption(
+      new Option("--name <name>", "Account name")
+        .default(DEFAULT_ACCOUNT_NAME)
+        .conflicts(["private-key"])
+    )
+    .addOption(
+      new Option("--network <network>", "Network to use")
+        .choices(["mainnet", "testnet"])
+        .default("testnet")
+    )
+    .addOption(
+      new Option(
+        "--private-key <key>",
+        "Private key for signing transactions"
+      ).conflicts(["name"])
+    )
+    .option(
+      "--gateway-zetachain <address>",
+      "Gateway contract address on ZetaChain"
+    )
+    .option("--revert-address <address>", "Revert address", ZeroAddress)
+    .option("--abort-address <address>", "Abort address", ZeroAddress)
+    .option("--call-on-revert", "Whether to call on revert", false)
+    .option(
+      "--on-revert-gas-limit <limit>",
+      "Gas limit for the revert transaction",
+      "7000000"
+    )
+    .option("--revert-message <message>", "Revert message", "0x")
+    .option(
+      "--tx-options-gas-limit <limit>",
+      "Gas limit for the transaction",
+      "7000000"
+    )
+    .option(
+      "--tx-options-gas-price <price>",
+      "Gas price for the transaction",
+      "10000000000"
+    )
+    .option(
+      "--call-options-gas-limit <limit>",
+      "Gas limit for the call",
+      "7000000"
+    )
+    .option("--call-options-is-arbitrary-call", "Call any function", false)
+    .option("--yes", "Skip confirmation prompt", false);
+};

--- a/utils/zetachain.command.helpers.ts
+++ b/utils/zetachain.command.helpers.ts
@@ -25,7 +25,7 @@ export const baseZetachainOptionsSchema = z.object({
   network: z.enum(["mainnet", "testnet"]).default("testnet"),
   onRevertGasLimit: numericStringSchema.default("7000000"),
   privateKey: evmPrivateKeySchema.optional(),
-  receiver: evmAddressSchema,
+  receiver: z.string(),
   revertAddress: evmAddressSchema,
   revertMessage: z.string().default("0x"),
   txOptionsGasLimit: numericStringSchema.default("7000000"),


### PR DESCRIPTION
closes: #253 

## EVM call

```bash
yarn zetachain zetachain call \
  --receiver 0x1c14000951495a98e5CcD9321eA10e690bd97bE0 \
  --gateway-zetachain 0x6c533f7fe93fae114d0954697069df33c9b74fd7 \
  --zrc20 0x236b0DE675cC8F46AE186897fCCeFe3370C9eDeD \
  --function "hello(string)" \
  --types string \
  --values foo \
  --name alice \
  --yes

# Transaction hash: 0xe92706c284e61113d1664f660427868f46c0888b5514b53202db796994c50996
```

<img width="1495" alt="image" src="https://github.com/user-attachments/assets/e2da2aeb-2269-4418-bdd4-4b2bbb9cf043" />

Tx in explorer: https://zetachain-testnet.blockscout.com/tx/0xe92706c284e61113d1664f660427868f46c0888b5514b53202db796994c50996?tab=index

## Non-evm call

```bash
yarn zetachain solana encode --connected CWJ5MngCuTKvDB2QayJ6k8m8ZAxPiGKCHfbAfv8bg6Gp --data hello --gateway ZETAjseVjuFsxdRxo6MmTCvqFwb3ZHUx56Co3vCmGis

# 0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000001200000000000000000000000000000000000000000000000000000000000000003aaf1b4e27d800e3810c607fdea7c3572a701710cd75e81b26f10830957d0f421000000000000000000000000000000000000000000000000000000000000000118a14c1ff4fdcdb919aadb9fc2340cc5047960db89930154409cccdf9a65bb42000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000568656c6c6f000000000000000000000000000000000000000000000000000000

yarn zetachain zetachain call \
  --data 0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000001200000000000000000000000000000000000000000000000000000000000000003aaf1b4e27d800e3810c607fdea7c3572a701710cd75e81b26f10830957d0f421000000000000000000000000000000000000000000000000000000000000000118a14c1ff4fdcdb919aadb9fc2340cc5047960db89930154409cccdf9a65bb42000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000568656c6c6f000000000000000000000000000000000000000000000000000000 \
  --receiver CWJ5MngCuTKvDB2QayJ6k8m8ZAxPiGKCHfbAfv8bg6Gp \
  --zrc20 0xADF73ebA3Ebaa7254E859549A44c74eF7cff7501 \
  --name alice \
  --abort-address 0x42496f92609e595c511d22cb8f24ceaf455378b8 \
  --revert-address 0x42496f92609e595c511d22cb8f24ceaf455378b8 \
  --call-options-gas-limit 1000000 \
  --on-revert-gas-limit 10000 \
  --yes
  
# Transaction hash: 0x736b77312b0732ae4a0d17822e96b8aceace11310740f32ae7d708183a9c24eb
```

<img width="1492" alt="image" src="https://github.com/user-attachments/assets/e20fa07b-359e-491d-abdc-0d382093f8b7" />

Tx in explorer: https://zetachain-testnet.blockscout.com/tx/0x736b77312b0732ae4a0d17822e96b8aceace11310740f32ae7d708183a9c24eb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced ZetaChain CLI commands, enabling users to call smart contracts on connected chains with support for both raw data and ABI-encoded function calls.
  - Added comprehensive command-line options and validation for ZetaChain transactions, including address, gas, and network parameters.
  - Enhanced CLI structure by grouping ZetaChain-related commands under a dedicated parent command.

- **Bug Fixes**
  - Improved validation to ensure consistency between function names, types, and values in contract calls.

- **Refactor**
  - Renamed EVM transaction helper functions for clarity and consistency.
  - Updated command modules to use EVM-specific helper functions.

- **Tests**
  - Added a new test case to verify correct encoding of Solana account addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->