### PR TITLE
feat: Add Zetachain withdraw and withdraw and call commands

### DIFF
--- a/packages/client/src/zetachainWithdrawAndCall.ts
+++ b/packages/client/src/zetachainWithdrawAndCall.ts
@@ -10,6 +10,7 @@ import {
   ZRC20Contract,
 } from "../../../types/contracts.types";
 import { ParseAbiValuesReturnType } from "../../../types/parseAbiValues.types";
+import { handleError } from "../../../utils/handleError";
 import { toHexString } from "../../../utils/toHexString";
 import { validateSigner } from "../../../utils/validateSigner";
 import { ZetaChainClient } from "./client";
@@ -30,6 +31,7 @@ import { ZetaChainClient } from "./client";
  * @param {any} args.callOptions - Call options.
  * @param {txOptions} args.txOptions - Transaction options such as gasPrice, nonce, etc.
  * @param {revertOptions} args.revertOptions - Options to handle call reversion, including revert address and message.
+ * @param {string} args.data - Optional raw data for non-EVM chains like Solana.
  *
  * @returns {object} - Returns an object containing the transaction, gas token, and gas fee.
  * @property {object} tx - The transaction object for the withdrawal and contract call.
@@ -42,13 +44,14 @@ export const zetachainWithdrawAndCall = async function (
   args: {
     amount: string;
     callOptions: CallOptions;
+    data?: string;
     function?: string;
     gatewayZetaChain?: string;
     receiver: string;
     revertOptions: RevertOptions;
     txOptions: TxOptions;
-    types: string[];
-    values: ParseAbiValuesReturnType;
+    types?: string[];
+    values?: ParseAbiValuesReturnType;
     zrc20: string;
   }
 ) {
@@ -67,18 +70,34 @@ export const zetachainWithdrawAndCall = async function (
     revertMessage: toHexString(args.revertOptions.revertMessage),
   };
 
-  const abiCoder = AbiCoder.defaultAbiCoder();
-  const encodedParameters = abiCoder.encode(args.types, args.values);
-
   let message: string;
 
-  if (args.callOptions.isArbitraryCall && args.function) {
-    const functionSignature = ethers.id(args.function).slice(0, 10);
-    message = ethers.hexlify(
-      ethers.concat([functionSignature, encodedParameters])
-    );
+  if (args.data) {
+    // For non-EVM chains, use the raw data directly
+    message = args.data.startsWith("0x") ? args.data : `0x${args.data}`;
+  } else if (args.types && args.values && args.function) {
+    // For EVM chains, encode the function and parameters
+    const abiCoder = AbiCoder.defaultAbiCoder();
+    const encodedParameters = abiCoder.encode(args.types, args.values);
+
+    if (args.callOptions.isArbitraryCall) {
+      const functionSignature = ethers.id(args.function).slice(0, 10);
+      message = ethers.hexlify(
+        ethers.concat([functionSignature, encodedParameters])
+      );
+    } else {
+      message = encodedParameters;
+    }
   } else {
-    message = encodedParameters;
+    const errorMessage = handleError({
+      context: "Invalid arguments",
+      error: new Error(
+        "Either provide 'data' OR provide all three of 'function', 'types', and 'values' together. These two approaches are mutually exclusive."
+      ),
+      shouldThrow: false,
+    });
+
+    throw new Error(errorMessage);
   }
 
   const zrc20 = new ethers.Contract(

--- a/packages/commands/src/zetachain/call.ts
+++ b/packages/commands/src/zetachain/call.ts
@@ -14,6 +14,7 @@ import {
   addCommonZetachainCommandOptions,
   baseZetachainOptionsSchema,
   confirmZetachainTransaction,
+  getZevmGatewayAddress,
   prepareCallOptions,
   prepareRevertOptions,
   prepareTxOptions,
@@ -43,15 +44,21 @@ const main = async (options: CallOptions) => {
   try {
     const { client } = setupZetachainTransaction(options);
 
+    const gatewayZetaChain = getZevmGatewayAddress(
+      options.network,
+      options.gatewayZetachain
+    );
+
     if (options.data) {
       console.log(`Contract call details:
 Raw data: ${options.data}
+ZetaChain Gateway: ${gatewayZetaChain}
 `);
 
       const response = await client.zetachainCall({
         callOptions: prepareCallOptions(options),
         data: options.data,
-        gatewayZetaChain: options.gatewayZetachain,
+        gatewayZetaChain,
         receiver: options.receiver,
         revertOptions: prepareRevertOptions(options),
         txOptions: prepareTxOptions(options),
@@ -66,6 +73,7 @@ Raw data: ${options.data}
 Function: ${options.function}
 Function parameters: ${options.values?.join(", ")}
 Parameter types: ${stringifiedTypes}
+ZetaChain Gateway: ${gatewayZetaChain}
 `);
 
       const isConfirmed = await confirmZetachainTransaction(options);

--- a/packages/commands/src/zetachain/call.ts
+++ b/packages/commands/src/zetachain/call.ts
@@ -6,7 +6,6 @@ import {
   hexStringSchema,
   namePkRefineRule,
   stringArraySchema,
-  typesAndDataExclusivityRefineRule,
   typesAndValuesLengthRefineRule,
 } from "../../../../types/shared.schema";
 import { handleError, validateAndParseSchema } from "../../../../utils";
@@ -31,10 +30,6 @@ const callOptionsSchema = baseZetachainOptionsSchema
   .refine(typesAndValuesLengthRefineRule.rule, {
     message: typesAndValuesLengthRefineRule.message,
     path: typesAndValuesLengthRefineRule.path,
-  })
-  .refine(typesAndDataExclusivityRefineRule.rule, {
-    message: typesAndDataExclusivityRefineRule.message,
-    path: typesAndDataExclusivityRefineRule.path,
   })
   .refine(functionTypesValuesConsistencyRule.rule, {
     message: functionTypesValuesConsistencyRule.message,

--- a/packages/commands/src/zetachain/index.ts
+++ b/packages/commands/src/zetachain/index.ts
@@ -1,9 +1,13 @@
 import { Command } from "commander";
 
 import { callCommand } from "./call";
+import { withdrawCommand } from "./withdraw";
+import { withdrawAndCallCommand } from "./withdrawAndCall";
 
 export const zetachainCommand = new Command("zetachain")
   .description("ZetaChain commands")
   .alias("z")
   .addCommand(callCommand)
+  .addCommand(withdrawCommand)
+  .addCommand(withdrawAndCallCommand)
   .helpCommand(false);

--- a/packages/commands/src/zetachain/withdraw.ts
+++ b/packages/commands/src/zetachain/withdraw.ts
@@ -7,6 +7,7 @@ import {
   addCommonZetachainCommandOptions,
   baseZetachainOptionsSchema,
   confirmZetachainTransaction,
+  getZevmGatewayAddress,
   prepareRevertOptions,
   prepareTxOptions,
   setupZetachainTransaction,
@@ -24,10 +25,16 @@ const main = async (options: WithdrawOptions) => {
   try {
     const { client } = setupZetachainTransaction(options);
 
+    const gatewayZetaChain = getZevmGatewayAddress(
+      options.network,
+      options.gatewayZetachain
+    );
+
     console.log(`Withdraw details:
 Amount: ${options.amount}
 Receiver: ${options.receiver}
 ZRC20: ${options.zrc20}
+ZetaChain Gateway: ${gatewayZetaChain}
 `);
 
     const isConfirmed = await confirmZetachainTransaction(options);
@@ -35,7 +42,7 @@ ZRC20: ${options.zrc20}
 
     const response = await client.zetachainWithdraw({
       amount: options.amount,
-      gatewayZetaChain: options.gatewayZetachain,
+      gatewayZetaChain,
       receiver: options.receiver,
       revertOptions: prepareRevertOptions(options),
       txOptions: prepareTxOptions(options),

--- a/packages/commands/src/zetachain/withdraw.ts
+++ b/packages/commands/src/zetachain/withdraw.ts
@@ -1,0 +1,72 @@
+import { Command } from "commander";
+import { z } from "zod";
+
+import { namePkRefineRule } from "../../../../types/shared.schema";
+import { handleError, validateAndParseSchema } from "../../../../utils";
+import {
+  addCommonZetachainCommandOptions,
+  baseZetachainOptionsSchema,
+  confirmZetachainTransaction,
+  prepareRevertOptions,
+  prepareTxOptions,
+  setupZetachainTransaction,
+} from "../../../../utils/zetachain.command.helpers";
+
+const withdrawOptionsSchema = baseZetachainOptionsSchema
+  .extend({
+    amount: z.string(),
+  })
+  .refine(namePkRefineRule);
+
+type WithdrawOptions = z.infer<typeof withdrawOptionsSchema>;
+
+const main = async (options: WithdrawOptions) => {
+  try {
+    const { client } = setupZetachainTransaction(options);
+
+    console.log(`Withdraw details:
+Amount: ${options.amount}
+Receiver: ${options.receiver}
+ZRC20: ${options.zrc20}
+`);
+
+    const isConfirmed = await confirmZetachainTransaction(options);
+    if (!isConfirmed) return;
+
+    const response = await client.zetachainWithdraw({
+      amount: options.amount,
+      gatewayZetaChain: options.gatewayZetachain,
+      receiver: options.receiver,
+      revertOptions: prepareRevertOptions(options),
+      txOptions: prepareTxOptions(options),
+      zrc20: options.zrc20,
+    });
+
+    const receipt = await response.tx.wait();
+    console.log("Transaction hash:", receipt?.hash);
+  } catch (error) {
+    handleError({
+      context: "Error during zetachain withdraw",
+      error,
+      shouldThrow: false,
+    });
+    process.exit(1);
+  }
+};
+
+export const withdrawCommand = new Command("withdraw").description(
+  "Withdraw tokens from ZetaChain to a connected chain"
+);
+
+addCommonZetachainCommandOptions(withdrawCommand)
+  .requiredOption("--amount <amount>", "The amount of tokens to withdraw")
+  .action(async (options) => {
+    const validatedOptions = validateAndParseSchema(
+      options,
+      withdrawOptionsSchema,
+      {
+        exitOnError: true,
+      }
+    );
+    await main(validatedOptions);
+  });

--- a/packages/commands/src/zetachain/withdrawAndCall.ts
+++ b/packages/commands/src/zetachain/withdrawAndCall.ts
@@ -14,6 +14,7 @@ import {
   addCommonZetachainCommandOptions,
   baseZetachainOptionsSchema,
   confirmZetachainTransaction,
+  getZevmGatewayAddress,
   prepareCallOptions,
   prepareRevertOptions,
   prepareTxOptions,
@@ -44,10 +45,16 @@ const main = async (options: WithdrawAndCallOptions) => {
   try {
     const { client } = setupZetachainTransaction(options);
 
+    const gatewayZetaChain = getZevmGatewayAddress(
+      options.network,
+      options.gatewayZetachain
+    );
+
     if (options.data) {
       console.log(`Withdraw and call details:
 Amount: ${options.amount}
 Raw data: ${options.data}
+ZetaChain Gateway: ${gatewayZetaChain}
 `);
 
       const isConfirmed = await confirmZetachainTransaction(options);
@@ -57,7 +64,7 @@ Raw data: ${options.data}
         amount: options.amount,
         callOptions: prepareCallOptions(options),
         data: options.data,
-        gatewayZetaChain: options.gatewayZetachain,
+        gatewayZetaChain,
         receiver: options.receiver,
         revertOptions: prepareRevertOptions(options),
         txOptions: prepareTxOptions(options),
@@ -73,6 +80,7 @@ Amount: ${options.amount}
 Function: ${options.function}
 Function parameters: ${options.values.join(", ")}
 Parameter types: ${stringifiedTypes}
+ZetaChain Gateway: ${gatewayZetaChain}
 `);
 
       const isConfirmed = await confirmZetachainTransaction(options);

--- a/packages/commands/src/zetachain/withdrawAndCall.ts
+++ b/packages/commands/src/zetachain/withdrawAndCall.ts
@@ -1,0 +1,150 @@
+import { Command, Option } from "commander";
+import { z } from "zod";
+
+import {
+  functionTypesValuesConsistencyRule,
+  hexStringSchema,
+  namePkRefineRule,
+  stringArraySchema,
+  typesAndValuesLengthRefineRule,
+} from "../../../../types/shared.schema";
+import { handleError, validateAndParseSchema } from "../../../../utils";
+import { parseAbiValues } from "../../../../utils/parseAbiValues";
+import {
+  addCommonZetachainCommandOptions,
+  baseZetachainOptionsSchema,
+  confirmZetachainTransaction,
+  prepareCallOptions,
+  prepareRevertOptions,
+  prepareTxOptions,
+  setupZetachainTransaction,
+} from "../../../../utils/zetachain.command.helpers";
+
+const withdrawAndCallOptionsSchema = baseZetachainOptionsSchema
+  .extend({
+    amount: z.string(),
+    data: hexStringSchema.optional(),
+    function: z.string().optional(),
+    types: stringArraySchema.optional(),
+    values: stringArraySchema.optional(),
+  })
+  .refine(typesAndValuesLengthRefineRule.rule, {
+    message: typesAndValuesLengthRefineRule.message,
+    path: typesAndValuesLengthRefineRule.path,
+  })
+  .refine(functionTypesValuesConsistencyRule.rule, {
+    message: functionTypesValuesConsistencyRule.message,
+    path: functionTypesValuesConsistencyRule.path,
+  })
+  .refine(namePkRefineRule);
+
+type WithdrawAndCallOptions = z.infer<typeof withdrawAndCallOptionsSchema>;
+
+const main = async (options: WithdrawAndCallOptions) => {
+  try {
+    const { client } = setupZetachainTransaction(options);
+
+    if (options.data) {
+      console.log(`Withdraw and call details:
+Amount: ${options.amount}
+Raw data: ${options.data}
+`);
+
+      const isConfirmed = await confirmZetachainTransaction(options);
+      if (!isConfirmed) return;
+
+      const response = await client.zetachainWithdrawAndCall({
+        amount: options.amount,
+        callOptions: prepareCallOptions(options),
+        data: options.data,
+        gatewayZetaChain: options.gatewayZetachain,
+        receiver: options.receiver,
+        revertOptions: prepareRevertOptions(options),
+        txOptions: prepareTxOptions(options),
+        zrc20: options.zrc20,
+      });
+
+      const receipt = await response.tx.wait();
+      console.log("Transaction hash:", receipt?.hash);
+    } else if (options.function && options.types && options.values) {
+      const stringifiedTypes = JSON.stringify(options.types);
+      console.log(`Withdraw and call details:
+Amount: ${options.amount}
+Function: ${options.function}
+Function parameters: ${options.values.join(", ")}
+Parameter types: ${stringifiedTypes}
+`);
+
+      const isConfirmed = await confirmZetachainTransaction(options);
+      if (!isConfirmed) return;
+
+      const values = parseAbiValues(stringifiedTypes, options.values);
+
+      const response = await client.zetachainWithdrawAndCall({
+        amount: options.amount,
+        callOptions: prepareCallOptions(options),
+        function: options.function,
+        gatewayZetaChain: options.gatewayZetachain,
+        receiver: options.receiver,
+        revertOptions: prepareRevertOptions(options),
+        txOptions: prepareTxOptions(options),
+        types: options.types,
+        values,
+        zrc20: options.zrc20,
+      });
+
+      const receipt = await response.tx.wait();
+      console.log("Transaction hash:", receipt?.hash);
+    } else {
+      handleError({
+        context: "Missing required parameters",
+        error: new Error(
+          "Either provide 'data' OR provide all three of 'function', 'types', and 'values'"
+        ),
+        shouldThrow: false,
+      });
+      process.exit(1);
+    }
+  } catch (error) {
+    handleError({
+      context: "Error during zetachain withdraw and call",
+      error,
+      shouldThrow: false,
+    });
+    process.exit(1);
+  }
+};
+
+export const withdrawAndCallCommand = new Command(
+  "withdraw-and-call"
+).description(
+  "Withdraw tokens from ZetaChain and call a contract on a connected chain"
+);
+
+addCommonZetachainCommandOptions(withdrawAndCallCommand)
+  .requiredOption("--amount <amount>", "The amount of tokens to withdraw")
+  .option(
+    "--function <function>",
+    `Function to call (example: "hello(string)")`
+  )
+  .option(
+    "--types <types...>",
+    "List of parameter types (e.g. uint256 address)"
+  )
+  .option("--values <values...>", "Parameter values for the function call")
+  .addOption(
+    new Option(
+      "--data <data>",
+      "Raw data for non-EVM chains like Solana"
+    ).conflicts(["types", "values", "function"])
+  )
+  .action(async (options) => {
+    const validatedOptions = validateAndParseSchema(
+      options,
+      withdrawAndCallOptionsSchema,
+      {
+        exitOnError: true,
+      }
+    );
+    await main(validatedOptions);
+  });

--- a/utils/zetachain.command.helpers.ts
+++ b/utils/zetachain.command.helpers.ts
@@ -1,4 +1,5 @@
 import confirm from "@inquirer/confirm";
+import { getAddress } from "@zetachain/protocol-contracts";
 import { Command, Option } from "commander";
 import { ethers, ZeroAddress } from "ethers";
 import { z } from "zod";
@@ -16,6 +17,7 @@ import { getAccountData } from "./accounts";
 import { getRpcUrl } from "./chains";
 import { handleError } from "./handleError";
 import { toHexString } from "./toHexString";
+import { validateAndParseSchema } from "./validateAndParseSchema";
 
 export const baseZetachainOptionsSchema = z.object({
   abortAddress: evmAddressSchema,
@@ -92,6 +94,37 @@ export const setupZetachainTransaction = (options: BaseZetachainOptions) => {
   });
 
   return { client };
+};
+
+/**
+ * @description This function is used to get the ZetaChain Gateway address.
+ * @param network - The network to use
+ * @param gatewayZetachain - The gateway ZetaChain address to use
+ * @returns The ZetaChain Gateway address
+ */
+export const getZevmGatewayAddress = (
+  network: "mainnet" | "testnet",
+  gatewayZetachain?: string
+): string => {
+  if (gatewayZetachain) {
+    const validatedProvidedAddress = validateAndParseSchema(
+      gatewayZetachain,
+      evmAddressSchema
+    );
+    return validatedProvidedAddress;
+  }
+
+  const defaultZetaChainGatewayAddress = getAddress(
+    "gateway",
+    network === "mainnet" ? "zeta_mainnet" : "zeta_testnet"
+  );
+
+  const validatedDefaultAddress = validateAndParseSchema(
+    defaultZetaChainGatewayAddress,
+    evmAddressSchema
+  );
+
+  return validatedDefaultAddress;
 };
 
 export const confirmZetachainTransaction = async (


### PR DESCRIPTION
## EVM withdraw and call

<img width="1498" alt="image" src="https://github.com/user-attachments/assets/2affa6cd-5abe-4665-a5dd-98c4250a5296" />

```bash
yarn zetachain zetachain withdraw-and-call \
  --amount 0.00001 \
  --receiver 0x1c14000951495a98e5CcD9321eA10e690bd97bE0 \
  --gateway-zetachain 0x6c533f7fe93fae114d0954697069df33c9b74fd7 \
  --zrc20 0x236b0DE675cC8F46AE186897fCCeFe3370C9eDeD \
  --function "hello(string)" \
  --types string \
  --values foo \
  --name alice \
  --yes

# ZetaChain tx hash: 0xc86d5c7c75ace5ec641a0a990a7a48313a368e55c25dc01b0b94c0e540f12e01
```

ZetaChain tx in explorer: https://zetachain-testnet.blockscout.com/tx/0xc86d5c7c75ace5ec641a0a990a7a48313a368e55c25dc01b0b94c0e540f12e01
ZetaChain cctx in explorer: https://athens.explorer.zetachain.com/cc/tx/0x38fd4cdf07f209dbd56a72e5fb9e119f661dc0035a805edd3edd2e331da3f7ef

## Solana withdraw and call

<img width="1497" alt="image" src="https://github.com/user-attachments/assets/0fb1fabf-578d-4adc-9afc-5d2c57277647" />

```bash
yarn zetachain solana encode --connected CWJ5MngCuTKvDB2QayJ6k8m8ZAxPiGKCHfbAfv8bg6Gp --data hello --gateway ZETAjseVjuFsxdRxo6MmTCvqFwb3ZHUx56Co3vCmGis

# 0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000001200000000000000000000000000000000000000000000000000000000000000003aaf1b4e27d800e3810c607fdea7c3572a701710cd75e81b26f10830957d0f421000000000000000000000000000000000000000000000000000000000000000118a14c1ff4fdcdb919aadb9fc2340cc5047960db89930154409cccdf9a65bb42000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000568656c6c6f000000000000000000000000000000000000000000000000000000

yarn zetachain zetachain withdraw-and-call \
  --data 0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000001200000000000000000000000000000000000000000000000000000000000000003aaf1b4e27d800e3810c607fdea7c3572a701710cd75e81b26f10830957d0f421000000000000000000000000000000000000000000000000000000000000000118a14c1ff4fdcdb919aadb9fc2340cc5047960db89930154409cccdf9a65bb42000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000568656c6c6f000000000000000000000000000000000000000000000000000000 \
  --amount 0.001 \
  --receiver CWJ5MngCuTKvDB2QayJ6k8m8ZAxPiGKCHfbAfv8bg6Gp \
  --zrc20 0xADF73ebA3Ebaa7254E859549A44c74eF7cff7501 \
  --name alice \
  --abort-address 0x42496f92609e595c511d22cb8f24ceaf455378b8 \
  --revert-address 0x42496f92609e595c511d22cb8f24ceaf455378b8 \
  --call-options-gas-limit 1000000 \
  --on-revert-gas-limit 10000 \
  --yes

# ZetaChain tx hash: 0x748e4e3a318842200a92c8eff6a90a96f2e80aaef7321ae1184a9d09bafb1e97
```

ZetaChain tx in explorer: https://zetachain-testnet.blockscout.com/tx/0x748e4e3a318842200a92c8eff6a90a96f2e80aaef7321ae1184a9d09bafb1e97
ZetaChain cctx in explorer: https://athens.explorer.zetachain.com/cc/tx/0xbf7e70f0e593cc0e970d2c99ffd62a9b8536ed1429dbb8249ebe56e155db858d

---

## EVM withdraw

<img width="1491" alt="image" src="https://github.com/user-attachments/assets/64310f4d-f844-4bb8-a503-b7de35017669" />

```bash
yarn zetachain z withdraw \
  --amount 0.00001 \
  --receiver 0x1c14000951495a98e5CcD9321eA10e690bd97bE0 \
  --gateway-zetachain 0x6c533f7fe93fae114d0954697069df33c9b74fd7 \
  --zrc20 0x236b0DE675cC8F46AE186897fCCeFe3370C9eDeD \
  --name alice \
  --yes

# ZetaChain tx hash: 0xedeff0efac3bf035064a424fa722cccbb80f3d0a867cc42c0151a0772994b274
```

ZetaChain tx in explorer: https://zetachain-testnet.blockscout.com/tx/0xedeff0efac3bf035064a424fa722cccbb80f3d0a867cc42c0151a0772994b274
ZetaChain cctx in explorer: https://athens.explorer.zetachain.com/cc/tx/0x58549808bf3e4a0d0841b12341688d3e69d9e0a448fb145a035851b8c62484a6

## Solana withdraw

<img width="1489" alt="image" src="https://github.com/user-attachments/assets/c1c5e0b4-ea73-436a-8a22-d0e9bee0cacd" />

```bash
yarn zetachain z withdraw \
  --amount 0.001 \
  --receiver 9WJaqVM2dcJ4G9b455QjVw6gTpmMGS8owVKZ3xhFo6fb \
  --gateway-zetachain 0x6c533f7fe93fae114d0954697069df33c9b74fd7 \
  --zrc20 0xADF73ebA3Ebaa7254E859549A44c74eF7cff7501 \
  --name alice \
  --yes

# ZetaChain tx hash: 0x38edb240bbf3bbdf9e747b59b8ddb329e5280815db8fdf0e5eb4aec5088601e4
```

ZetaChain tx in explorer: https://zetachain-testnet.blockscout.com/tx/0x38edb240bbf3bbdf9e747b59b8ddb329e5280815db8fdf0e5eb4aec5088601e4
ZetaChain cctx in explorer: https://athens.explorer.zetachain.com/cc/tx/0x3ce29bb9c3ee72334637d1b259cf4d42798d028207c9b1e5ac540f50716cf1c0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new CLI command to withdraw tokens from ZetaChain to a connected chain.
	- Introduced a new CLI command to withdraw tokens and perform a contract call on a connected chain, supporting both raw data (for non-EVM chains) and function call parameters (for EVM chains).
- **Improvements**
	- Enhanced the withdraw-and-call functionality to support mutually exclusive input methods for contract call data.
	- Expanded the ZetaChain CLI with new subcommands for withdrawal and withdraw-and-call operations.
	- Improved gateway address handling by deriving and validating the gateway address based on network and input parameters.
- **Bug Fixes**
	- Improved error handling and input validation for withdraw and contract call commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->