### PR TITLE
feat(zetachain): display withdraw gas fee

### DIFF
--- a/packages/commands/src/zetachain/call.ts
+++ b/packages/commands/src/zetachain/call.ts
@@ -1,4 +1,5 @@
 import { Command, Option } from "commander";
+import { ethers } from "ethers";
 import { z } from "zod";
 
 import {
@@ -15,6 +16,7 @@ import {
   baseZetachainOptionsSchema,
   confirmZetachainTransaction,
   getZevmGatewayAddress,
+  getZRC20WithdrawFee,
   prepareCallOptions,
   prepareRevertOptions,
   prepareTxOptions,
@@ -49,9 +51,16 @@ const main = async (options: CallOptions) => {
       options.gatewayZetachain
     );
 
+    const { gasFee, gasSymbol } = await getZRC20WithdrawFee(
+      client.signer as ethers.ContractRunner,
+      options.zrc20,
+      options.callOptionsGasLimit
+    );
+
     if (options.data) {
       console.log(`Contract call details:
 Raw data: ${options.data}
+Withdraw Gas Fee: ${gasFee} ${gasSymbol}
 ZetaChain Gateway: ${gatewayZetaChain}
 `);
 
@@ -73,6 +82,7 @@ ZetaChain Gateway: ${gatewayZetaChain}
 Function: ${options.function}
 Function parameters: ${options.values?.join(", ")}
 Parameter types: ${stringifiedTypes}
+Withdraw Gas Fee: ${gasFee} ${gasSymbol}
 ZetaChain Gateway: ${gatewayZetaChain}
 `);
 

--- a/packages/commands/src/zetachain/withdraw.ts
+++ b/packages/commands/src/zetachain/withdraw.ts
@@ -1,4 +1,5 @@
 import { Command } from "commander";
+import { ethers } from "ethers";
 import { z } from "zod";
 
 import { namePkRefineRule } from "../../../../types/shared.schema";
@@ -8,6 +9,7 @@ import {
   baseZetachainOptionsSchema,
   confirmZetachainTransaction,
   getZevmGatewayAddress,
+  getZRC20WithdrawFee,
   prepareRevertOptions,
   prepareTxOptions,
   setupZetachainTransaction,
@@ -30,8 +32,14 @@ const main = async (options: WithdrawOptions) => {
       options.gatewayZetachain
     );
 
+    const { gasFee, gasSymbol, zrc20Symbol } = await getZRC20WithdrawFee(
+      client.signer as ethers.ContractRunner,
+      options.zrc20
+    );
+
     console.log(`Withdraw details:
-Amount: ${options.amount}
+Amount: ${options.amount} ${zrc20Symbol}
+Withdraw Gas Fee: ${gasFee} ${gasSymbol}
 Receiver: ${options.receiver}
 ZRC20: ${options.zrc20}
 ZetaChain Gateway: ${gatewayZetaChain}

--- a/packages/commands/src/zetachain/withdrawAndCall.ts
+++ b/packages/commands/src/zetachain/withdrawAndCall.ts
@@ -1,4 +1,5 @@
 import { Command, Option } from "commander";
+import { ethers } from "ethers";
 import { z } from "zod";
 
 import {
@@ -15,6 +16,7 @@ import {
   baseZetachainOptionsSchema,
   confirmZetachainTransaction,
   getZevmGatewayAddress,
+  getZRC20WithdrawFee,
   prepareCallOptions,
   prepareRevertOptions,
   prepareTxOptions,
@@ -50,9 +52,15 @@ const main = async (options: WithdrawAndCallOptions) => {
       options.gatewayZetachain
     );
 
+    const { gasFee, gasSymbol, zrc20Symbol } = await getZRC20WithdrawFee(
+      client.signer as ethers.ContractRunner,
+      options.zrc20
+    );
+
     if (options.data) {
       console.log(`Withdraw and call details:
-Amount: ${options.amount}
+Amount: ${options.amount} ${zrc20Symbol}
+Withdraw Gas Fee: ${gasFee} ${gasSymbol}
 Raw data: ${options.data}
 ZetaChain Gateway: ${gatewayZetaChain}
 `);
@@ -76,7 +84,8 @@ ZetaChain Gateway: ${gatewayZetaChain}
     } else if (options.function && options.types && options.values) {
       const stringifiedTypes = JSON.stringify(options.types);
       console.log(`Withdraw and call details:
-Amount: ${options.amount}
+Amount: ${options.amount} ${zrc20Symbol}
+Withdraw Gas Fee: ${gasFee} ${gasSymbol}
 Function: ${options.function}
 Function parameters: ${options.values.join(", ")}
 Parameter types: ${stringifiedTypes}

--- a/packages/commands/src/zetachain/withdrawAndCall.ts
+++ b/packages/commands/src/zetachain/withdrawAndCall.ts
@@ -54,7 +54,8 @@ const main = async (options: WithdrawAndCallOptions) => {
 
     const { gasFee, gasSymbol, zrc20Symbol } = await getZRC20WithdrawFee(
       client.signer as ethers.ContractRunner,
-      options.zrc20
+      options.zrc20,
+      options.callOptionsGasLimit
     );
 
     if (options.data) {

--- a/types/contracts.types.ts
+++ b/types/contracts.types.ts
@@ -39,10 +39,11 @@ export type ZRC20Contract = ethers.Contract & {
     txOptions: TxOptions
   ) => Promise<ContractTransactionResponse>;
   decimals: () => Promise<number>;
-  withdrawGasFee: () => Promise<[string, ethers.BigNumberish]>;
+  symbol: () => Promise<string>;
+  withdrawGasFee: () => Promise<[string, bigint]>;
   withdrawGasFeeWithGasLimit: (
     gasLimit: ethers.BigNumberish
-  ) => Promise<[string, ethers.BigNumberish]>;
+  ) => Promise<[string, bigint]>;
 };
 
 export type GatewayContract = ethers.Contract & {

--- a/utils/zetachain.command.helpers.ts
+++ b/utils/zetachain.command.helpers.ts
@@ -194,7 +194,8 @@ export const prepareCallOptions = (options: BaseZetachainOptions) => {
 
 export const getZRC20WithdrawFee = async (
   provider: ethers.ContractRunner,
-  zrc20: string
+  zrc20: string,
+  gasLimit?: string
 ): Promise<{
   gasFee: string;
   gasSymbol: string;
@@ -206,11 +207,16 @@ export const getZRC20WithdrawFee = async (
     ZRC20ABI.abi,
     provider
   ) as ZRC20Contract;
+  let gasZRC20: string;
+  let gasFee: bigint;
   const zrc20Symbol = (await contract.symbol()) as string;
-  const [gasZRC20, gasFee] = (await contract.withdrawGasFee()) as [
-    string,
-    bigint
-  ];
+  if (gasLimit) {
+    [gasZRC20, gasFee] = (await contract.withdrawGasFeeWithGasLimit(
+      gasLimit
+    )) as [string, bigint];
+  } else {
+    [gasZRC20, gasFee] = (await contract.withdrawGasFee()) as [string, bigint];
+  }
   const gasContract = new ethers.Contract(
     gasZRC20,
     ZRC20ABI.abi,

--- a/utils/zetachain.command.helpers.ts
+++ b/utils/zetachain.command.helpers.ts
@@ -1,7 +1,9 @@
 import confirm from "@inquirer/confirm";
 import { getAddress } from "@zetachain/protocol-contracts";
+import ZRC20ABI from "@zetachain/protocol-contracts/abi/ZRC20.sol/ZRC20.json";
 import { Command, Option } from "commander";
 import { ethers, ZeroAddress } from "ethers";
+import { ZRC20Contract } from "types/contracts.types";
 import { z } from "zod";
 
 import { ZetaChainClient } from "../packages/client/src/client";
@@ -188,6 +190,28 @@ export const prepareCallOptions = (options: BaseZetachainOptions) => {
     gasLimit: options.callOptionsGasLimit,
     isArbitraryCall: options.callOptionsIsArbitraryCall,
   };
+};
+
+export const getZRC20WithdrawFee = async (
+  provider: ethers.ContractRunner,
+  zrc20: string
+) => {
+  const contract = new ethers.Contract(
+    zrc20,
+    ZRC20ABI.abi,
+    provider
+  ) as ZRC20Contract;
+  const zrc20Symbol = await contract.symbol();
+  const [gasZRC20, gasFee] = await contract.withdrawGasFee();
+  const gasContract = new ethers.Contract(
+    gasZRC20,
+    ZRC20ABI.abi,
+    provider
+  ) as ZRC20Contract;
+  const decimals = await gasContract.decimals();
+  const gasSymbol = await gasContract.symbol();
+  const gasFeeFormatted = ethers.formatUnits(gasFee, decimals);
+  return { gasFee: gasFeeFormatted, gasSymbol, gasZRC20, zrc20Symbol };
 };
 
 export const addCommonZetachainCommandOptions = (command: Command) => {

--- a/utils/zetachain.command.helpers.ts
+++ b/utils/zetachain.command.helpers.ts
@@ -195,21 +195,29 @@ export const prepareCallOptions = (options: BaseZetachainOptions) => {
 export const getZRC20WithdrawFee = async (
   provider: ethers.ContractRunner,
   zrc20: string
-) => {
+): Promise<{
+  gasFee: string;
+  gasSymbol: string;
+  gasZRC20: string;
+  zrc20Symbol: string;
+}> => {
   const contract = new ethers.Contract(
     zrc20,
     ZRC20ABI.abi,
     provider
   ) as ZRC20Contract;
-  const zrc20Symbol = await contract.symbol();
-  const [gasZRC20, gasFee] = await contract.withdrawGasFee();
+  const zrc20Symbol = (await contract.symbol()) as string;
+  const [gasZRC20, gasFee] = (await contract.withdrawGasFee()) as [
+    string,
+    bigint
+  ];
   const gasContract = new ethers.Contract(
     gasZRC20,
     ZRC20ABI.abi,
     provider
   ) as ZRC20Contract;
   const decimals = await gasContract.decimals();
-  const gasSymbol = await gasContract.symbol();
+  const gasSymbol = (await gasContract.symbol()) as string;
   const gasFeeFormatted = ethers.formatUnits(gasFee, decimals);
   return { gasFee: gasFeeFormatted, gasSymbol, gasZRC20, zrc20Symbol };
 };

--- a/utils/zetachain.command.helpers.ts
+++ b/utils/zetachain.command.helpers.ts
@@ -209,13 +209,11 @@ export const getZRC20WithdrawFee = async (
   ) as ZRC20Contract;
   let gasZRC20: string;
   let gasFee: bigint;
-  const zrc20Symbol = (await contract.symbol()) as string;
+  const zrc20Symbol = await contract.symbol();
   if (gasLimit) {
-    [gasZRC20, gasFee] = (await contract.withdrawGasFeeWithGasLimit(
-      gasLimit
-    )) as [string, bigint];
+    [gasZRC20, gasFee] = await contract.withdrawGasFeeWithGasLimit(gasLimit);
   } else {
-    [gasZRC20, gasFee] = (await contract.withdrawGasFee()) as [string, bigint];
+    [gasZRC20, gasFee] = await contract.withdrawGasFee();
   }
   const gasContract = new ethers.Contract(
     gasZRC20,
@@ -223,7 +221,7 @@ export const getZRC20WithdrawFee = async (
     provider
   ) as ZRC20Contract;
   const decimals = await gasContract.decimals();
-  const gasSymbol = (await gasContract.symbol()) as string;
+  const gasSymbol = await gasContract.symbol();
   const gasFeeFormatted = ethers.formatUnits(gasFee, decimals);
   return { gasFee: gasFeeFormatted, gasSymbol, gasZRC20, zrc20Symbol };
 };


### PR DESCRIPTION
I think it's important to show withdraw gas fee, because a user is charged with this amount on top of the `--amount` they specified.

## Withdraw

```
yarn zetachain z withdraw \
  --amount 0.001 \
  --zrc20 0xcC683A782f4B30c138787CB5576a86AF66fdc31d \
  --receiver 0x4955a3F38ff86ae92A914445099caa8eA2B9bA32
```

```
Withdraw details:
Amount: 0.001 USDC.SEPOLIA
Withdraw Gas Fee: 0.0000002152472 sETH.SEPOLIA
Receiver: 0x4955a3F38ff86ae92A914445099caa8eA2B9bA32
ZRC20: 0xcC683A782f4B30c138787CB5576a86AF66fdc31d
ZetaChain Gateway: 0x6c533f7fe93fae114d0954697069df33c9b74fd7
```

## Withdraw and call (with gas limit)

```
 yarn zetachain z withdraw-and-call \
  --amount 0.001 \
  --zrc20 0xcC683A782f4B30c138787CB5576a86AF66fdc31d \
  --receiver 0x4955a3F38ff86ae92A914445099caa8eA2B9bA32 \
  --types string \
  --values hello \
  --function "hello(string)"
```

```
Withdraw and call details:
Amount: 0.001 USDC.SEPOLIA
Withdraw Gas Fee: 0.000014740334 sETH.SEPOLIA
Function: hello(string)
Function parameters: hello
Parameter types: ["string"]
ZetaChain Gateway: 0x6c533f7fe93fae114d0954697069df33c9b74fd7
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Console output for contract calls and withdrawals now displays the withdrawal gas fee and its token symbol.
  - Withdrawn token amounts are now shown with their token symbols for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->