### PR TITLE
fix: add btc memo missing credential args

### DIFF
--- a/packages/commands/src/bitcoin/memo/deposit.ts
+++ b/packages/commands/src/bitcoin/memo/deposit.ts
@@ -21,7 +21,6 @@ type DepositOptions = z.infer<typeof memoDepositOptionsSchema>;
 
 const main = async (options: DepositOptions) => {
   try {
-    console.log("options", options);
     const { key, address } = setupBitcoinKeyPair(
       options.privateKey,
       options.name

--- a/packages/commands/src/bitcoin/memo/deposit.ts
+++ b/packages/commands/src/bitcoin/memo/deposit.ts
@@ -21,6 +21,7 @@ type DepositOptions = z.infer<typeof memoDepositOptionsSchema>;
 
 const main = async (options: DepositOptions) => {
   try {
+    console.log("options", options);
     const { key, address } = setupBitcoinKeyPair(
       options.privateKey,
       options.name

--- a/utils/bitcoin.command.helpers.ts
+++ b/utils/bitcoin.command.helpers.ts
@@ -229,6 +229,16 @@ export const createBitcoinCommandWithCommonOptions = (
       "-g, --gateway <address>",
       "Bitcoin gateway (TSS) address",
       DEFAULT_GATEWAY
+    )
+    .addOption(
+      new Option("--private-key <key>", "Bitcoin private key").conflicts([
+        "name",
+      ])
+    )
+    .addOption(
+      new Option("--name <name>", "Account name")
+        .default(DEFAULT_ACCOUNT_NAME)
+        .conflicts(["private-key"])
     );
 };
 
@@ -244,16 +254,6 @@ export const createBitcoinInscriptionCommandWithCommonOptions = (
   name: string
 ): Command => {
   return createBitcoinCommandWithCommonOptions(name)
-    .addOption(
-      new Option("--private-key <key>", "Bitcoin private key").conflicts([
-        "name",
-      ])
-    )
-    .addOption(
-      new Option("--name <name>", "Account name")
-        .default(DEFAULT_ACCOUNT_NAME)
-        .conflicts(["private-key"])
-    )
     .option("--revert-address <address>", "Revert address")
     .addOption(
       new Option("--format <format>", "Encoding format")


### PR DESCRIPTION
## Before

<img width="1438" alt="image" src="https://github.com/user-attachments/assets/8358f4d5-1899-41cb-8bc1-eb1fa687f09c" />

## After

### Available testnet bitcoin accounts

<img width="1507" alt="image" src="https://github.com/user-attachments/assets/279cdbeb-a248-4a10-9f44-f4297e6ba24f" />

### No `private-key` nor `name` (defaults to the default account)

<img width="1504" alt="image" src="https://github.com/user-attachments/assets/3daa2265-542b-45cd-9b9c-99b6d67fd7d8" />

### Only `private-key` provided

<img width="1507" alt="image" src="https://github.com/user-attachments/assets/5764c7ff-e3cb-4482-95c8-5dfaffb35481" />

### Only `name` provided

<img width="1505" alt="image" src="https://github.com/user-attachments/assets/7de8aa2c-4b3b-4903-a48b-f2dd3f130e2c" />

### Both `private-key` and `name` provided

<img width="1507" alt="image" src="https://github.com/user-attachments/assets/5c22a9cc-ce5b-4b18-9d12-ce1fe1eafe9a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal consistency of command options for Bitcoin-related commands. No changes to user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->