### PR TITLE
docs(readme): replace with a URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,3 @@ await zetachainCall(
 
 All Toolkit capabilities are also exposed through [`zetachain`
 CLI](https://github.com/zeta-chain/cli).
-
-## 🧑‍💻 Documentation
-
-Full API reference is in [docs/index.md](https://github.com/zeta-chain/toolkit/blob/main/docs/index.md).

--- a/README.md
+++ b/README.md
@@ -55,9 +55,4 @@ CLI](https://github.com/zeta-chain/cli).
 ## 🧑‍💻 Documentation
 
 Full API reference, architecture guides, and recipes live in the [docs
-site](docs/index.md).
-
-## 🤝 Contributing
-
-Issues and PRs are welcome! Please read the [contributing
-guide](CONTRIBUTING.md) before getting started.
+site]([docs/index.md](https://github.com/zeta-chain/toolkit/blob/main/docs/index.md)).

--- a/README.md
+++ b/README.md
@@ -54,5 +54,4 @@ CLI](https://github.com/zeta-chain/cli).
 
 ## 🧑‍💻 Documentation
 
-Full API reference, architecture guides, and recipes live in the [docs
-site]([docs/index.md](https://github.com/zeta-chain/toolkit/blob/main/docs/index.md)).
+Full API reference is in [docs/index.md](https://github.com/zeta-chain/toolkit/blob/main/docs/index.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,8 +58,7 @@ CLI](https://github.com/zeta-chain/cli).
 
 ## 🧑‍💻 Documentation
 
-Full API reference, architecture guides, and recipes live in the [docs
-site]([docs/index.md](https://github.com/zeta-chain/toolkit/blob/main/docs/index.md)).
+Full API reference is in [docs/index.md](https://github.com/zeta-chain/toolkit/blob/main/docs/index.md).
 
 ## Functions
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,12 +59,7 @@ CLI](https://github.com/zeta-chain/cli).
 ## 🧑‍💻 Documentation
 
 Full API reference, architecture guides, and recipes live in the [docs
-site](docs/index.md).
-
-## 🤝 Contributing
-
-Issues and PRs are welcome! Please read the [contributing
-guide](CONTRIBUTING.md) before getting started.
+site]([docs/index.md](https://github.com/zeta-chain/toolkit/blob/main/docs/index.md)).
 
 ## Functions
 


### PR DESCRIPTION
To avoid breaking the linker check in the docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Simplified the README by removing the "Contributing" section.
  * Updated the documentation site link to use a full GitHub URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->