### PR TITLE
ci: add Foundry setup to publish npm workflow

### DIFF
--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -18,6 +18,12 @@ jobs:
           node-version: "21"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Install Foundry Dependencies
+        run: forge install foundry-rs/forge-std
+
       - name: Install Dependencies
         run: yarn install
 


### PR DESCRIPTION
This should fix the build step in publish npm workflow: https://github.com/zeta-chain/toolkit/actions/runs/16144990956

Seems to be working fine: https://github.com/zeta-chain/toolkit/actions/runs/16145880261/job/45564472068

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the publishing workflow to include Foundry toolchain and dependency installation steps before building and publishing to NPM.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->