### PR TITLE
fix: nonce too low error when depositing on localnet

### DIFF
--- a/utils/gatewayEvm.ts
+++ b/utils/gatewayEvm.ts
@@ -258,11 +258,22 @@ export const broadcastGatewayTx = async ({
 }: BroadcastGatewayTxArgs): Promise<ethers.ContractTransactionResponse> => {
   const nonceManager = new NonceManager(signer);
 
+  let nonce;
+  try {
+    nonce = await nonceManager.getNonce();
+  } catch (error) {
+    console.error(
+      "Failed to retrieve nonce while preparing gateway transaction:",
+      error
+    );
+    nonce = undefined;
+  }
+
   const options = {
     data: txData.data,
     gasLimit: txOptions.gasLimit,
     gasPrice: txOptions.gasPrice,
-    nonce: await nonceManager.getNonce(),
+    nonce,
     to: txData.to,
     ...(txData.value ? { value: txData.value } : {}),
   };

--- a/utils/gatewayEvm.ts
+++ b/utils/gatewayEvm.ts
@@ -262,8 +262,8 @@ export const broadcastGatewayTx = async ({
     data: txData.data,
     gasLimit: txOptions.gasLimit,
     gasPrice: txOptions.gasPrice,
-    to: txData.to,
     nonce: await nonceManager.getNonce(),
+    to: txData.to,
     ...(txData.value ? { value: txData.value } : {}),
   };
 

--- a/utils/gatewayEvm.ts
+++ b/utils/gatewayEvm.ts
@@ -1,5 +1,11 @@
 import GatewayEvmAbi from "@zetachain/protocol-contracts/abi/GatewayEVM.sol/GatewayEVM.json";
-import { AbiCoder, ethers, InterfaceAbi, ZeroAddress } from "ethers";
+import {
+  AbiCoder,
+  ethers,
+  InterfaceAbi,
+  NonceManager,
+  ZeroAddress,
+} from "ethers";
 
 import { RevertOptions, TxOptions } from "../types/contracts.types";
 import { ParseAbiValuesReturnType } from "../types/parseAbiValues.types";
@@ -250,11 +256,14 @@ export const broadcastGatewayTx = async ({
   txData,
   txOptions,
 }: BroadcastGatewayTxArgs): Promise<ethers.ContractTransactionResponse> => {
+  const nonceManager = new NonceManager(signer);
+
   const options = {
     data: txData.data,
     gasLimit: txOptions.gasLimit,
     gasPrice: txOptions.gasPrice,
     to: txData.to,
+    nonce: await nonceManager.getNonce(),
     ...(txData.value ? { value: txData.value } : {}),
   };
 


### PR DESCRIPTION
Calling EVM Gateway functions with `--erc20` on Localnet resulted in a nonce error:

```
yarn zetachain evm deposit --receiver 0xB82008565FdC7e44609fA118A4a681E92581e680 --gateway 0x68B1D87F95878fE05B998F19b66F4baba5De1aed --rpc http://localhost:8545 --amount 0.11 --yes --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --erc20 0x5eb3Bc0a489C5A8288765d2336659EbCA68FCd00
```

```
From:   0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
To:     0xB82008565FdC7e44609fA118A4a681E92581e680 on ZetaChain
Amount: 0.11 USDC
Refund: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
Call on revert: false

Proceeding with transaction (--yes flag set)
Error depositing to EVM: nonce has already been used (transaction="0x02f901b6827a6981a98502540be3f88502540be40883010f999468b1d87f95878fe05b998f19b66f4baba5de1aed80b90144102614b0000000000000000000000000b82008565fdc7e44609fa118a4a681e92581e6800000000000000000000000000000000000000000000000000186cc6acd4b00000000000000000000000000005eb3bc0a489c5a8288765d2336659ebca68fcd000000000000000000000000000000000000000000000000000000000000000080000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb922660000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000030d400000000000000000000000000000000000000000000000000000000000000000c080a0ee11c241a61512602024cf0a2c133a015d136e51822473a08d5a1c06115126c2a0177c7ee2e5f05593a85f90c84abb6c8c3964b534f839feda8d27ea1988f7a0ef", info={ "error": { "code": -32003, "message": "nonce too low" } }, code=NONCE_EXPIRED, version=6.15.0)
```

For some reason Ethers does not correctly set the nonce. This only happened

With this fix using nonce manager, commands work fine both on testnet and localnet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction reliability by introducing explicit nonce management when broadcasting gateway transactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->