### PR TITLE
ci: use Soldeer for managing Solidity dependencies

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,9 +21,6 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
 
-      - name: Install Foundry Dependencies
-        run: forge install foundry-rs/forge-std
-
       - name: Install Dependencies
         run: yarn install
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -23,6 +23,9 @@ jobs:
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
 
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
       - name: Install dependencies
         run: yarn install
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,6 +18,9 @@ jobs:
           node-version: "21"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
       - name: Install Dependencies
         run: yarn install
 

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -11,4 +11,4 @@ jobs:
       - name: PR Conventional Commit Validation
         uses: ytanikin/pr-conventional-commits@1.4.1
         with:
-          task_types: '["feat","fix","docs","test","ci","refactor","chore", "dependabot"]'
+          task_types: '["feat","fix","docs","test","ci","refactor","chore","dependabot"]'

--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -21,9 +21,6 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
 
-      - name: Install Foundry Dependencies
-        run: forge install foundry-rs/forge-std
-
       - name: Install Dependencies
         run: yarn install
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,6 +18,9 @@ jobs:
           node-version: "21"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
       - name: Install Dependencies
         run: yarn install
 

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ lib
 out
 
 cache_hardhat
+
+dependencies

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,10 +56,6 @@ await zetachainCall(
 All Toolkit capabilities are also exposed through [`zetachain`
 CLI](https://github.com/zeta-chain/cli).
 
-## 🧑‍💻 Documentation
-
-Full API reference is in [docs/index.md](https://github.com/zeta-chain/toolkit/blob/main/docs/index.md).
-
 ## Functions
 
 ### evmCall()

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,13 +1,15 @@
 [profile.default]
 src = 'contracts'
+out = 'out'
+viaIR = true
+libs = ['node_modules', "dependencies"]
+test = 'test'
+cache_path  = 'cache_forge'
+verbosity = 3
 fs_permissions = [{ access = "read", path = "./node_modules" }]
-via_ir = false
-optimizer = true
-optimizer_runs = 200
-auto_detect_solc = true
-libs = ["node_modules", "lib"]
 remappings = [
-    "forge-std/=lib/forge-std/src/",
-    "@openzeppelin/contracts-upgradeable/=node_modules/@openzeppelin/contracts-upgradeable/",
-    "@openzeppelin/contracts/=node_modules/@openzeppelin/contracts/"
+  "forge-std/=dependencies/forge-std-1.9.7/src/",
 ]
+
+[dependencies]
+forge-std = "1.9.7"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "zetachain:build": "yarn build && node dist/packages/commands/src/program.js",
-    "zetachain": "npx ts-node packages/commands/src/program.ts"
+    "zetachain": "npx ts-node packages/commands/src/program.ts",
+    "postinstall": "forge soldeer update"
   },
   "keywords": [],
   "author": "ZetaChain",

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,3 +1,1 @@
-forge-std/=lib/forge-std/src/
-@openzeppelin/contracts-upgradeable/=node_modules/@openzeppelin/contracts-upgradeable/
-@openzeppelin/contracts/=node_modules/@openzeppelin/contracts/ 
+forge-std-1.9.7/=dependencies/forge-std-1.9.7/

--- a/soldeer.lock
+++ b/soldeer.lock
@@ -1,0 +1,6 @@
+[[dependencies]]
+name = "forge-std"
+version = "1.9.7"
+url = "https://soldeer-revisions.s3.amazonaws.com/forge-std/1_9_7_28-04-2025_15:55:08_forge-std-1.9.zip"
+checksum = "8d9e0a885fa8ee6429a4d344aeb6799119f6a94c7c4fe6f188df79b0dce294ba"
+integrity = "9e60fdba82bc374df80db7f2951faff6467b9091873004a3d314cf0c084b3c7d"


### PR DESCRIPTION
Using [Soldeer](https://soldeer.xyz/) `forge soldeer`, same as in protocol and example contracts. `forge soldeer update` runs automatically after `yarn install`.

Soldeer is better than using `forge install` directly, because it doesn't create git submodules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to streamline Foundry installation and dependency management.
  * Improved workflow configuration formatting for clarity.
  * Added the "dependencies" directory to .gitignore.
  * Updated configuration files to refine build profiles, library paths, and remappings.
  * Introduced a post-install script for automated dependency updates.
  * Simplified and consolidated remapping references for dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->