### PR TITLE
fix: added error message to CCTX tracking

### DIFF
--- a/packages/commands/src/query/cctx.ts
+++ b/packages/commands/src/query/cctx.ts
@@ -177,8 +177,11 @@ Receiver: ${receiver}
     mainTx += `Status:   ${status}, ${status_message}\n`;
   }
 
-  if (error_message !== "") {
-    mainTx += `Error:    ${error_message}\n`;
+  // Prevents blank or whitespace-only entries and keeps console output clean
+  const trimmedErrorMessage = error_message.trim();
+
+  if (trimmedErrorMessage) {
+    mainTx += `Error:    ${trimmedErrorMessage}\n`;
   }
 
   output += mainTx;

--- a/packages/commands/src/query/cctx.ts
+++ b/packages/commands/src/query/cctx.ts
@@ -125,7 +125,7 @@ const formatCCTX = (cctx: CrossChainTx) => {
   } = cctx;
   const { sender_chain_id, sender, amount, coin_type } = inbound_params;
   const { receiver_chainId, receiver } = outbound_params[0];
-  const { status, status_message } = cctx_status;
+  const { status, status_message, error_message } = cctx_status;
   const {
     revert_address,
     call_on_revert,
@@ -175,6 +175,10 @@ Receiver: ${receiver}
 
   if (status_message !== "") {
     mainTx += `Status:   ${status}, ${status_message}\n`;
+  }
+
+  if (error_message !== "") {
+    mainTx += `Error:    ${error_message}\n`;
   }
 
   output += mainTx;

--- a/packages/commands/src/query/cctx.ts
+++ b/packages/commands/src/query/cctx.ts
@@ -125,7 +125,7 @@ const formatCCTX = (cctx: CrossChainTx) => {
   } = cctx;
   const { sender_chain_id, sender, amount, coin_type } = inbound_params;
   const { receiver_chainId, receiver } = outbound_params[0];
-  const { status, status_message, error_message } = cctx_status;
+  const { status, status_message, error_message = "" } = cctx_status;
   const {
     revert_address,
     call_on_revert,


### PR DESCRIPTION
```
yarn -s zetachain q cctx --hash 0x84e7b41ae9baad590b066b6bc64caa36f81e3a0d5eb95ee95f2014891b651ad7
```
```
11155111 → 7001 ❌ Reverted
CCTX:     0xf65e6eff782dd5ea0e77e5996a19863b4081a353ec398cce222f2c381faa6298
Tx Hash:  0x84e7b41ae9baad590b066b6bc64caa36f81e3a0d5eb95ee95f2014891b651ad7 (on chain 11155111)
Tx Hash:  0x2861595d0ded67beb21feddb322e1de56aa5a1111d952e802564bc8268fb09ee (on chain 7001)
Sender:   0x3DEB339E4F76B44D0Bcc92D2440ebE159Df0Daf6
Receiver: 0x62B153fB51F262620EBFc543450407Fe9aa395C5
Message:  000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000db7b22696e74656e74223a7b2274797065223a2273776170222c22736f75726365436861696e223a31313135353131312c22736f75726365546f6b656e223a22455448222c22746172676574436861696e223a31383333322c22746172676574546f6b656e223a22425443222c22616d6f756e74223a302e30317d2c227374657073223a5b5d2c2273756d6d617279223a7b22736f75726365416d6f756e74223a22302e303120455448222c22746172676574416d6f756e74223a227e302e3030303120425443222c22666565223a22302e30303120455448227d7d0000000000
Amount:   100000000000000 Gas tokens
Error:    {"type":"contract_call_error","message":"contract call failed when calling EVM with data","error":"execution reverted: ret 0x: evm transaction execution failed","method":"depositAndCall0","contract":"0x6c533f7fE93fAE114d0954697069Df33C9B74fD7","args":"[{[61 235 51 158 79 118 180 77 11 204 146 210 68 14 190 21 157 240 218 246] 0x3DEB339E4F76B44D0Bcc92D2440ebE159Df0Daf6 11155111} 0x05BA149A7bd6dC1F937fA9046A9e05C05f3b18b0 100000000000000 0x62B153fB51F262620EBFc543450407Fe9aa395C5 [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 32 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 219 123 34 105 110 116 101 110 116 34 58 123 34 116 121 112 101 34 58 34 115 119 97 112 34 44 34 115 111 117 114 99 101 67 104 97 105 110 34 58 49 49 49 53 53 49 49 49 44 34 115 111 117 114 99 101 84 111 107 101 110 34 58 34 69 84 72 34 44 34 116 97 114 103 101 116 67 104 97 105 110 34 58 49 56 51 51 50 44 34 116 97 114 103 101 116 84 111 107 101 110 34 58 34 66 84 67 34 44 34 97 109 111 117 110 116 34 58 48 46 48 49 125 44 34 115 116 101 112 115 34 58 91 93 44 34 115 117 109 109 97 114 121 34 58 123 34 115 111 117 114 99 101 65 109 111 117 110 116 34 58 34 48 46 48 49 32 69 84 72 34 44 34 116 97 114 103 101 116 65 109 111 117 110 116 34 58 34 126 48 46 48 48 48 49 32 66 84 67 34 44 34 102 101 101 34 58 34 48 46 48 48 49 32 69 84 72 34 125 125 0 0 0 0 0]]"}

7001 → 11155111 ✅ Revert executed
Revert Address:   0x3DEB339E4F76B44D0Bcc92D2440ebE159Df0Daf6
Call on Revert:   false
Abort Address:    0x3DEB339E4F76B44D0Bcc92D2440ebE159Df0Daf6
Revert Message:   null
Revert Gas Limit: 300000
Tx Hash:          0x075911b0e8f371f52f22f32878b228f5d9c696353bc31e164f4281621e9ca5d5 (on chain 11155111)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Status views for cross-chain transactions now display a dedicated "Error" line when a meaningful error message is present.
- **Bug Fixes**
  - Whitespace-only or empty error texts are suppressed so blank messages no longer appear in summaries.
- **Chores**
  - Added error reporting to transaction summaries without changing existing status formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->