### PR TITLE
fix(balances): by getting EVM RPC from Viem instead of @zetachain/networks

### DIFF
--- a/packages/client/src/getBalances.ts
+++ b/packages/client/src/getBalances.ts
@@ -14,6 +14,7 @@ import {
   getTonBalances,
   prepareMulticallContexts,
 } from "../../../utils/balances";
+import { getRpcUrl } from "../../../utils/chains";
 import { ZetaChainClient } from "./client";
 
 /**
@@ -79,7 +80,7 @@ export const getBalances = async function (
       );
       if (!chain) continue;
 
-      const rpc = this.getEndpoint("evm", chain.name);
+      const rpc = getRpcUrl(parseInt(chain.chain_id));
       let chainBalances: TokenBalance[];
 
       try {

--- a/utils/chains.ts
+++ b/utils/chains.ts
@@ -1,53 +1,15 @@
-import { networks } from "@zetachain/networks";
-import { type NetworksSchema } from "@zetachain/networks/dist/src/types";
-
-export const getChainName = (chainId: number): string => {
-  const typedNetworks = networks as NetworksSchema;
-  const network = Object.values(typedNetworks).find(
-    (n) => n.chain_id === chainId
-  );
-
-  if (!network) {
-    throw new Error(`Network with chain ID ${chainId} not found`);
-  }
-
-  return network.chain_name;
-};
+import * as viemChains from "viem/chains";
 
 export const getRpcUrl = (chainId: number): string => {
-  const typedNetworks = networks as NetworksSchema;
-  const network = Object.values(typedNetworks).find(
-    (n) => n.chain_id === chainId
-  );
+  const chain = Object.values(viemChains).find((c) => c.id === chainId);
 
-  if (!network) {
-    throw new Error(`Network with chain ID ${chainId} not found`);
+  if (!chain) {
+    throw new Error(`Chain with ID ${chainId} not found in viem/chains`);
   }
 
-  if (!network.api) {
-    throw new Error(`Network with chain ID ${chainId} has no API endpoints`);
+  const url = chain.rpcUrls?.default?.http?.[0];
+  if (!url) {
+    throw new Error(`No RPC HTTP URL found for chain ID ${chainId}`);
   }
-
-  const evmRpc = network.api.find((api) => api.type === "evm");
-  if (!evmRpc) {
-    throw new Error(`Network with chain ID ${chainId} has no EVM RPC endpoint`);
-  }
-
-  return evmRpc.url;
-};
-
-export const getNetworkTypeByChainId = (
-  chainId: number
-): "mainnet" | "testnet" => {
-  const typedNetworks = networks as NetworksSchema;
-  const network = Object.values(typedNetworks).find(
-    (n) => n.chain_id === chainId
-  );
-
-  if (!network?.type) {
-    throw new Error(`Network with chain ID ${chainId} not found`);
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-  return network.type;
+  return url;
 };


### PR DESCRIPTION
* fix: query balances
* refactor: get EVM RPC from Viem instead of @zetachain/networks

`query balances` is broken right now, because Kaia is in [supported networks](https://zetachain-athens.blockpi.network/lcd/v1/public/zeta-chain/observer/supportedChains) but not in `@zetachain/networks`. Instead of maintaining the networks package, we're better off just using Viem for this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized how RPC endpoints are determined by relying on a single, authoritative chain definition source.
* **Bug Fixes**
  * Improved reliability when selecting a default RPC endpoint.
  * Clearer error messages when a chain is unsupported or lacks an RPC URL.
* **Chores**
  * Aligned internal logic and messaging with the new chain data source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->