### PR TITLE
Refactor: Rename Solana --recipient flag to --receiver

### DIFF
--- a/packages/client/src/solanaDeposit.ts
+++ b/packages/client/src/solanaDeposit.ts
@@ -18,7 +18,7 @@ export const solanaDeposit = async function (
   this: ZetaChainClient,
   args: {
     amount: number;
-    recipient: string;
+    receiver: string;
   }
 ) {
   if (!this.isSolanaWalletConnected()) {
@@ -84,7 +84,7 @@ export const solanaDeposit = async function (
 
   try {
     const tx = new anchor.web3.Transaction();
-    const recipient = Buffer.from(ethers.getBytes(args.recipient));
+    const recipient = Buffer.from(ethers.getBytes(args.receiver));
     const depositInstruction = await gatewayProgram.methods
       .deposit(depositAmount, recipient)
       .accounts({

--- a/packages/client/src/solanaDepositAndCall.ts
+++ b/packages/client/src/solanaDepositAndCall.ts
@@ -19,7 +19,7 @@ export const solanaDepositAndCall = async function (
   this: ZetaChainClient,
   args: {
     amount: number;
-    recipient: string;
+    receiver: string;
     types: string[];
     values: ParseAbiValuesReturnType;
   }
@@ -87,7 +87,7 @@ export const solanaDepositAndCall = async function (
 
   try {
     const tx = new anchor.web3.Transaction();
-    const recipient = Buffer.from(ethers.getBytes(args.recipient));
+    const recipient = Buffer.from(ethers.getBytes(args.receiver));
 
     if (!Array.isArray(args.types) || !Array.isArray(args.values)) {
       throw new Error(

--- a/packages/commands/src/solana/call.ts
+++ b/packages/commands/src/solana/call.ts
@@ -32,7 +32,7 @@ const main = async (options: CallOptions) => {
   await confirmSolanaTx({
     api: API,
     message: values.join(", "),
-    recipient: options.recipient,
+    receiver: options.receiver,
     revertOptions: createRevertOptions(revertOptions, keypair.publicKey),
     sender: keypair.publicKey.toBase58(),
   });
@@ -40,7 +40,7 @@ const main = async (options: CallOptions) => {
   try {
     const tx = await solanaCall(
       {
-        receiver: options.recipient,
+        receiver: options.receiver,
         revertOptions,
         types: options.types,
         values,

--- a/packages/commands/src/solana/deposit.ts
+++ b/packages/commands/src/solana/deposit.ts
@@ -30,7 +30,7 @@ const main = async (options: DepositOptions) => {
     amount: options.amount,
     api: API,
     mint: options.mint,
-    recipient: options.recipient,
+    receiver: options.receiver,
     revertOptions: createRevertOptions(revertOptions, keypair.publicKey),
     sender: keypair.publicKey.toBase58(),
   });
@@ -39,7 +39,7 @@ const main = async (options: DepositOptions) => {
     const tx = await solanaDeposit(
       {
         amount: options.amount,
-        receiver: options.recipient,
+        receiver: options.receiver,
         revertOptions,
         token: options.mint,
       },

--- a/packages/commands/src/solana/depositAndCall.ts
+++ b/packages/commands/src/solana/depositAndCall.ts
@@ -35,7 +35,7 @@ const main = async (options: DepositAndCallOptions) => {
     api: API,
     message: values.join(", "),
     mint: options.mint,
-    recipient: options.recipient,
+    receiver: options.receiver,
     revertOptions: createRevertOptions(revertOptions, keypair.publicKey),
     sender: keypair.publicKey.toBase58(),
   });
@@ -44,7 +44,7 @@ const main = async (options: DepositAndCallOptions) => {
     const tx = await solanaDepositAndCall(
       {
         amount: options.amount,
-        receiver: options.recipient,
+        receiver: options.receiver,
         revertOptions,
         token: options.mint,
         types: options.types,

--- a/packages/tasks/src/solanaDeposit.ts
+++ b/packages/tasks/src/solanaDeposit.ts
@@ -11,7 +11,7 @@ import { ZetaChainClient } from "../../client/src";
 const solanaDepositArgsSchema = z.object({
   amount: z.string(),
   idPath: z.string(),
-  recipient: z.string(),
+  receiver: z.string(),
   solanaNetwork: z.string(),
 });
 
@@ -29,16 +29,16 @@ export const solanaDeposit = async (args: SolanaDepositArgs) => {
   });
   let recipient: string;
   try {
-    if (bech32.decode(parsedArgs.recipient)) {
+    if (bech32.decode(parsedArgs.receiver)) {
       recipient = ethers.solidityPacked(
         ["bytes"],
-        [ethers.toUtf8Bytes(parsedArgs.recipient)]
+        [ethers.toUtf8Bytes(parsedArgs.receiver)]
       );
     } else {
-      recipient = parsedArgs.recipient;
+      recipient = parsedArgs.receiver;
     }
   } catch {
-    recipient = parsedArgs.recipient;
+    recipient = parsedArgs.receiver;
   }
   const { amount } = args;
   const res = await client.solanaDeposit({ amount: Number(amount), recipient });
@@ -85,6 +85,6 @@ export const getKeypairFromFile = async (filepath: string) => {
 
 task("solana-deposit", "Solana deposit", solanaDeposit)
   .addParam("amount", "Amount of SOL to deposit")
-  .addParam("recipient", "Universal contract address")
+  .addParam("receiver", "Universal contract address")
   .addOptionalParam("solanaNetwork", "Solana Network", "devnet")
   .addOptionalParam("idPath", "Path to id.json", "~/.config/solana/id.json");

--- a/packages/tasks/src/solanaDepositAndCall.ts
+++ b/packages/tasks/src/solanaDepositAndCall.ts
@@ -16,7 +16,7 @@ import { ZetaChainClient } from "../../client/src";
 const solanaDepositAndCallArgsSchema = z.object({
   amount: z.string(),
   idPath: z.string(),
-  recipient: z.string(),
+  receiver: z.string(),
   solanaNetwork: z.string(),
   types: validJsonStringSchema,
   values: z.array(z.string()).min(1, "At least one value is required"),
@@ -43,16 +43,16 @@ export const solanaDepositAndCall = async (args: SolanaDepositAndCallArgs) => {
   let recipient: string;
 
   try {
-    if (bech32.decode(parsedArgs.recipient)) {
+    if (bech32.decode(parsedArgs.receiver)) {
       recipient = ethers.solidityPacked(
         ["bytes"],
-        [ethers.toUtf8Bytes(parsedArgs.recipient)]
+        [ethers.toUtf8Bytes(parsedArgs.receiver)]
       );
     } else {
-      recipient = parsedArgs.recipient;
+      recipient = parsedArgs.receiver;
     }
   } catch {
-    recipient = parsedArgs.recipient;
+    recipient = parsedArgs.receiver;
   }
 
   const paramTypes = parseJson(parsedArgs.types, stringArraySchema);
@@ -109,7 +109,7 @@ export const getKeypairFromFile = async (filepath: string) => {
 
 task("solana-deposit-and-call", "Solana deposit and call", solanaDepositAndCall)
   .addParam("amount", "Amount of SOL to deposit")
-  .addParam("recipient", "Universal contract address")
+  .addParam("receiver", "Universal contract address")
   .addOptionalParam("solanaNetwork", "Solana Network", "devnet")
   .addOptionalParam("idPath", "Path to id.json", "~/.config/solana/id.json")
   .addParam("types", "The types of the parameters (example: ['string'])")

--- a/utils/solana.commands.helpers.ts
+++ b/utils/solana.commands.helpers.ts
@@ -30,7 +30,7 @@ export const baseSolanaOptionsSchema = z.object({
   name: z.string().optional(),
   onRevertGasLimit: z.string(),
   privateKey: z.string().optional(),
-  recipient: z.string(),
+  receiver: z.string(),
   revertAddress: z.string().optional(),
   revertMessage: z.string(),
 });
@@ -212,7 +212,7 @@ export const isSOLBalanceSufficient = async (
 export const createSolanaCommandWithCommonOptions = (name: string): Command => {
   return new Command(name)
     .requiredOption(
-      "--recipient <recipient>",
+      "--receiver <receiver>",
       "EOA or contract address on ZetaChain"
     )
     .addOption(
@@ -289,14 +289,14 @@ export const confirmSolanaTx = async (options: {
   api: string;
   message?: string;
   mint?: string;
-  recipient: string;
+  receiver: string;
   revertOptions: SolanaRevertOptions;
   sender: string;
 }) => {
   console.log(`
 Network: ${options.api}
 Sender: ${options.sender}
-Recipient: ${options.recipient}
+Recipient: ${options.receiver}
 Revert options: ${JSON.stringify(options.revertOptions)}${
     options.message ? `\nMessage: ${options.message}` : ""
   }${options.amount ? `\nAmount: ${options.amount}` : ""}${


### PR DESCRIPTION
### Summary
This PR renames the `--recipient` command-line flag to `--receiver` for all Solana-related commands. This change is made to ensure consistency with the existing `--receiver` flag already in use by other commands, such as `zetachain z withdraw`.

### Changes made
- **Renamed the flag:** Changed `--recipient` to `--receiver` in the following files:
    - `packages/commands/src/solana/{call, deposit, depositAndCall}.ts`
    - `packages/tasks/src/{solanaDeposit, solanaDepositAndCall}.ts`
    - `packages/client/src/{solanaDeposit, solanaDepositAndCall}.ts`
    - `utils/solana.commands.helpers.ts`

- **Ensured consistency:**
    - Modified schema, confirmation prompts, and internal variables to be consistent with `receiver`.

### How to test
You can test this change by running the following commands with the new `--receiver` flag:
- `solana call --receiver <address>`
- `solana deposit --receiver <address>`
- `solana deposit-and-call --receiver <address>`

### Related Issue
Closes #397