### PR TITLE
feat: add zetachain chain export path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,17 @@
+# Claude Code Guidelines
+
+## Pull Requests
+
+When asked to create a PR, use `gh pr create` with:
+
+- Title: semantic, comparing current branch to main (e.g., "feat: add new hook", "fix: resolve memory leak")
+- Use bang notation for breaking changes (e.g., "feat!: important feature")
+- Description should be concise and include:
+  - Summary of changes
+  - **Integration**: how to integrate changes from the SDK into a client app (can be empty if nothing required)
+  - **Breaking Changes**: what will break by upgrading the SDK (if any)
+- Do not include the "🤖 Generated with Claude Code" footer
+
+## Branches
+
+When asked to create a branch, run `git diff` to analyze the changes, then use `git checkout -b` with a semantic branch name based on the diff (e.g., "feat/add-new-hook", "fix/resolve-memory-leak"). Do not ask the user what the branch should be for.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,11 @@
       "import": "./dist/esm/src/chains/solana/index.js",
       "default": "./dist/cjs/src/chains/solana/index.js"
     },
+    "./chains/zetachain": {
+      "types": "./dist/types/src/chains/zetachain/index.d.ts",
+      "import": "./dist/esm/src/chains/zetachain/index.js",
+      "default": "./dist/cjs/src/chains/zetachain/index.js"
+    },
     "./tasks": {
       "types": "./dist/types/packages/tasks/src/index.d.ts",
       "import": "./dist/esm/packages/tasks/src/index.js",


### PR DESCRIPTION
## Summary

Add the `./chains/zetachain` export entry to `package.json`, allowing consumers to import zetachain-specific modules via `@zetachain/toolkit/chains/zetachain`.

Also adds `CLAUDE.md` with project conventions.

## Integration

Import zetachain modules directly:

```ts
import { ... } from "@zetachain/toolkit/chains/zetachain";
```

## Breaking Changes

None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new `package.json` export path and a contributor guidelines doc, with no runtime logic changes. Main risk is packaging/build breakage if the referenced `dist/.../chains/zetachain` outputs are missing or misnamed.
> 
> **Overview**
> Adds a new `package.json` `exports` entry for `./chains/zetachain`, enabling consumers to import `@zetachain/toolkit/chains/zetachain` with proper ESM/CJS and type resolution.
> 
> Also introduces `CLAUDE.md` documenting project conventions for branch naming and PR creation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa3da5a34efe062612c57a99f986945d6af23981. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added zetachain module to public exports, making it available for use in the package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->